### PR TITLE
We need to send a 200 response back not a response with string OK as the response body.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",

--- a/routes/azureSpecials.js
+++ b/routes/azureSpecials.js
@@ -81,7 +81,7 @@ var specials = function (coverage) {
 
     if (scenario === subscription) {
         coverage[coverageScenario]++;
-        res.send(200).end();
+        res.status(200).end();
     } else {
            utils.send400(res, next, 'Expected subscription: "' + util.inspect(scenario) + '" did not match actual "' + subscription + '"');
     }
@@ -131,7 +131,7 @@ var specials = function (coverage) {
 
     if (scenario === apiVersion || (scenario === 'null' && Object.keys(req.query).length === 0)) {
         coverage[coverageScenario]++;
-        res.send(200).end();
+        res.status(200).end();
     } else {
            utils.send400(res, next, 'Expected api-version: "' + util.inspect(scenario) + '" did not match actual "' + apiVersion + '"');
     }


### PR DESCRIPTION
Before this change, the server was sending `"OK"` (string OK) response and this fails `JSON.parse()` deserialization in the TS runtime. 
- Fixing it to match the swagger spec.