### PR TITLE
Quirks

### DIFF
--- a/swagger/body-boolean.quirks.json
+++ b/swagger/body-boolean.quirks.json
@@ -1,0 +1,177 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "AutoRest Bool Test Service",
+        "description": "Test Infrastructure for AutoRest",
+        "version": "1.0.0"
+    },
+    "host": "localhost",
+    "schemes": [
+        "http"
+    ],
+    "produces": [ "application/json"],
+    "consumes": [ "application/json"],
+    "paths": {
+        "/bool/true": {
+            "get": {
+                "operationId": "bool_getTrue",
+                "description": "Get true Boolean value",
+                "tags": [
+                    "Bool Operations"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The true Boolean value",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "operationId": "bool_putTrue",
+                "description": "Set Boolean value true",
+                "parameters": [
+                    {
+                        "name": "boolBody",
+                        "in": "body",
+                        "schema" : {
+                            "type": "boolean"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Bool Operations"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Empty Response"
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/bool/false": {
+            "get": {
+                "operationId": "bool_getFalse",
+                "description": "Get false Boolean value",
+                "tags": [
+                    "Bool Operations"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The false Boolean value",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            },
+            "put": {
+                "operationId": "bool_putFalse",
+                "description": "Set Boolean value false",
+                "parameters": [
+                    {
+                        "name": "boolBody",
+                        "in": "body",
+                        "schema" : {
+                            "type": "boolean"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Bool Operations"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Empty Response"
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+         "/bool/null": {
+            "get": {
+                "operationId": "bool_getNull",
+                "description": "Get null Boolean value",
+                "tags": [
+                    "Bool Operations"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The null Boolean value",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/bool/invalid": {
+            "get": {
+                "operationId": "bool_getInvalid",
+                "description": "Get invalid Boolean value",
+                "tags": [
+                    "Bool Operations"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The invalid Boolean value",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Error": {
+            "properties": {
+                "status": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/swagger/body-number.quirks.json
+++ b/swagger/body-number.quirks.json
@@ -1,0 +1,596 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "AutoRest Number Test Service",
+    "description": "Test Infrastructure for AutoRest",
+    "version": "1.0.0"
+  },
+  "host": "localhost",
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/number/null": {
+      "get": {
+        "operationId": "number_getNull",
+        "description": "Get null Number value",
+        "responses": {
+          "200": {
+            "description": "The null number value",
+            "schema": {
+              "type": "number"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/invalidfloat": {
+      "get": {
+        "operationId": "number_getInvalidFloat",
+        "description": "Get invalid float Number value",
+        "responses": {
+          "200": {
+            "description": "The invalid float number value",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/invaliddouble": {
+      "get": {
+        "operationId": "number_getInvalidDouble",
+        "description": "Get invalid double Number value",
+        "responses": {
+          "200": {
+            "description": "The invalid double number value",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/invaliddecimal": {
+      "get": {
+        "operationId": "number_getInvalidDecimal",
+        "description": "Get invalid decimal Number value",
+        "responses": {
+          "200": {
+            "description": "The invalid decimal number value",
+            "schema": {
+              "type": "number",
+              "format": "decimal"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/big/float/3.402823e+20": {
+      "put": {
+        "operationId": "number_putBigFloat",
+        "description": "Put big float value 3.402823e+20",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The big float value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getBigFloat",
+        "description": "Get big float value 3.402823e+20",
+        "responses": {
+          "200": {
+            "description": "The big float value",
+            "schema": {
+              "type": "number",
+              "format": "float",
+              "enum":  [3.402823e+20]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/big/double/2.5976931e+101": {
+      "put": {
+        "operationId": "number_putBigDouble",
+        "description": "Put big double value 2.5976931e+101",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The big double value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getBigDouble",
+        "description": "Get big double value 2.5976931e+101",
+        "responses": {
+          "200": {
+            "description": "The big double value 2.5976931e+101",
+            "schema": {
+              "type": "number",
+              "format": "double",
+              "enum":  [2.5976931e+101]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/big/double/99999999.99": {
+      "put": {
+        "operationId": "number_putBigDoublePositiveDecimal",
+        "description": "Put big double value 99999999.99",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The big double value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getBigDoublePositiveDecimal",
+        "description": "Get big double value 99999999.99",
+        "responses": {
+          "200": {
+            "description": "The big double value 99999999.99",
+            "schema": {
+              "type": "number",
+              "format": "double",
+              "enum":  [99999999.99]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/big/double/-99999999.99": {
+      "put": {
+        "operationId": "number_putBigDoubleNegativeDecimal",
+        "description": "Put big double value -99999999.99",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The big double value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getBigDoubleNegativeDecimal",
+        "description": "Get big double value -99999999.99",
+        "responses": {
+          "200": {
+            "description": "The big double value -99999999.99",
+            "schema": {
+              "type": "number",
+              "format": "double",
+              "enum":  [-99999999.99]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/big/decimal/2.5976931e+101": {
+      "put": {
+        "operationId": "number_putBigDecimal",
+        "description": "Put big decimal value 2.5976931e+101",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "decimal"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The big decimal value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getBigDecimal",
+        "description": "Get big decimal value 2.5976931e+101",
+        "responses": {
+          "200": {
+            "description": "The big decimal value 2.5976931e+101",
+            "schema": {
+              "type": "number",
+              "format": "decimal",
+              "enum":  [2.5976931e+101]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/big/decimal/99999999.99": {
+      "put": {
+        "operationId": "number_putBigDecimalPositiveDecimal",
+        "description": "Put big decimal value 99999999.99",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "decimal"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The big decimal value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getBigDecimalPositiveDecimal",
+        "description": "Get big decimal value 99999999.99",
+        "responses": {
+          "200": {
+            "description": "The big decimal value 99999999.99",
+            "schema": {
+              "type": "number",
+              "format": "decimal",
+              "enum":  [99999999.99]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/big/decimal/-99999999.99": {
+      "put": {
+        "operationId": "number_putBigDecimalNegativeDecimal",
+        "description": "Put big decimal value -99999999.99",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "decimal"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The big decimal value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getBigDecimalNegativeDecimal",
+        "description": "Get big decimal value -99999999.99",
+        "responses": {
+          "200": {
+            "description": "The big decimal value -99999999.99",
+            "schema": {
+              "type": "number",
+              "format": "decimal",
+              "enum":  [-99999999.99]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/small/float/3.402823e-20": {
+      "put": {
+        "operationId": "number_putSmallFloat",
+        "description": "Put small float value 3.402823e-20",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "float"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The small float value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getSmallFloat",
+        "description": "Get big double value 3.402823e-20",
+        "responses": {
+          "200": {
+            "description": "The big double value 3.402823e-20",
+            "schema": {
+              "type": "number",
+              "format": "double",
+              "enum":  [3.402823e-20]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/small/double/2.5976931e-101": {
+      "put": {
+        "operationId": "number_putSmallDouble",
+        "description": "Put small double value 2.5976931e-101",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The small double value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getSmallDouble",
+        "description": "Get big double value 2.5976931e-101",
+        "responses": {
+          "200": {
+            "description": "The big double value 2.5976931e-101",
+            "schema": {
+              "type": "number",
+              "format": "double",
+              "enum":  [2.5976931e-101]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/number/small/decimal/2.5976931e-101": {
+      "put": {
+        "operationId": "number_putSmallDecimal",
+        "description": "Put small decimal value 2.5976931e-101",
+        "parameters": [
+          {
+            "name": "numberBody",
+            "in": "body",
+            "schema": {
+              "type": "number",
+              "format": "decimal"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The small decimal value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "number_getSmallDecimal",
+        "description": "Get small decimal value 2.5976931e-101",
+        "responses": {
+          "200": {
+            "description": "The small decimal value 2.5976931e-101",
+            "schema": {
+              "type": "number",
+              "format": "decimal",
+              "enum":  [2.5976931e-101]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "properties": {
+        "status": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/swagger/body-string.quirks.json
+++ b/swagger/body-string.quirks.json
@@ -1,0 +1,538 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "AutoRest Swagger BAT Service",
+    "description": "Test Infrastructure for AutoRest Swagger BAT",
+    "version": "1.0.0"
+  },
+  "host": "localhost",
+  "schemes": [
+    "http"
+  ],
+  "produces": [ "application/json" ],
+  "consumes": [ "application/json" ],
+  "paths": {
+    "/string/null": {
+      "get": {
+        "operationId": "string_getNull",
+        "description": "Get null string value value",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The null String value",
+            "schema": {
+              "type": "string",
+              "enum": [ null ]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "string_putNull",
+        "description": "Set string value null",
+        "parameters": [
+          {
+            "name": "stringBody",
+            "in": "body",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/empty": {
+      "get": {
+        "operationId": "string_getEmpty",
+        "description": "Get empty string value value ''",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The empty String value",
+            "schema": {
+              "type": "string",
+              "enum": [ "" ]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "string_putEmpty",
+        "description": "Set string value empty ''",
+        "parameters": [
+          {
+            "name": "stringBody",
+            "in": "body",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/mbcs": {
+      "get": {
+        "operationId": "string_getMbcs",
+        "description": "Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The mbcs String value",
+            "schema": {
+              "type": "string",
+              "enum": [ "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€" ]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "string_putMbcs",
+        "description": "Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'",
+        "parameters": [
+          {
+            "name": "stringBody",
+            "in": "body",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/whitespace": {
+      "get": {
+        "operationId": "string_getWhitespace",
+        "description": "Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'",
+            "schema": {
+              "type": "string",
+              "enum": [ "    Now is the time for all good men to come to the aid of their country    " ]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "string_putWhitespace",
+        "description": "Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'",
+        "parameters": [
+          {
+            "name": "stringBody",
+            "in": "body",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/enum/notExpandable": {
+      "get": {
+        "operationId": "enum_getNotExpandable",
+        "description": "Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The String value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'",
+            "schema": {
+              "x-ms-enum": { "name": "Colors", "modelAsString": false},
+              "type": "string",
+              "enum": [ "red color", "green-color", "blue_color" ]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "enum_putNotExpandable",
+        "description": "Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'",
+        "parameters": [
+          {
+            "name": "stringBody",
+            "in": "body",
+            "schema": {
+              "x-ms-enum": { "name": "Colors", "modelAsString": false},
+              "type": "string",
+              "enum": [ "red color", "green-color", "blue_color" ]
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/enum/Referenced": {
+      "get": {
+        "operationId": "enum_getReferenced",
+        "description": "Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The String value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'",
+            "schema": {
+              "$ref": "#/definitions/RefColors"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "enum_putReferenced",
+        "description": "Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'",
+        "parameters": [
+          {
+            "name": "enumStringBody",
+            "in": "body",
+             "schema": {
+              "$ref": "#/definitions/RefColors"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/enum/ReferencedConstant": {
+      "get": {
+        "operationId": "enum_getReferencedConstant",
+        "description": "Get value 'green-color' from the constant.",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The String value 'green-color' from a constant",
+            "schema": {
+              "$ref": "#/definitions/RefColorConstant"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "enum_putReferencedConstant",
+        "description": "Sends value 'green-color' from a constant",
+        "parameters": [
+          {
+            "name": "enumStringBody",
+            "in": "body",
+             "schema": {
+              "$ref": "#/definitions/RefColorConstant"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/notProvided": {
+      "get": {
+        "operationId": "string_getNotProvided",
+        "description": "Get String value when no string value is sent in response payload",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The not provided string value",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/base64Encoding": {
+      "get": {
+        "operationId": "string_getBase64Encoded",
+        "description": "Get value that is base64 encoded",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The base64 encoded string value",
+            "schema": {
+              "type": "string",
+              "format": "base64url"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/base64UrlEncoding": {
+      "get": {
+        "operationId": "string_getBase64UrlEncoded",
+        "description": "Get value that is base64url encoded",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The base64url encoded string value",
+            "schema": {
+              "type": "string",
+              "format": "base64url"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "string_putBase64UrlEncoded",
+        "description": "Put value that is base64url encoded",
+        "parameters": [
+          {
+            "name": "stringBody",
+            "in": "body",
+            "schema": {
+              "type": "string",
+              "format": "base64url"
+            },
+            "required": true
+          }
+        ],
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/string/nullBase64UrlEncoding": {
+      "get": {
+        "operationId": "string_getNullBase64UrlEncoded",
+        "description": "Get null value that is expected to be base64url encoded",
+        "tags": [
+          "String Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "The null value",
+            "schema": {
+              "type": "string",
+              "format": "base64url"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "properties": {
+        "status": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "RefColors": {
+      "x-ms-enum": { "name": "Colors", "modelAsString": false},
+      "type": "string",
+      "enum": [ "red color", "green-color", "blue_color" ],
+      "description": "Referenced Color Enum Description."
+    },
+    "RefColorConstant": {
+      "properties": {       
+        "ColorConstant": {   
+          "x-ms-enum": { "name": "ColorConstant", "modelAsString": false},
+          "type": "string",
+          "enum": [ "green-color" ],
+          "description": "Referenced Color Constant Description."
+        },
+         "field1": {            
+          "type": "string",          
+          "description": "Sample string."
+        }
+      },
+       "required": [ "ColorConstant" ]
+    }
+  }
+}

--- a/swagger/composite-swagger.quirks.json
+++ b/swagger/composite-swagger.quirks.json
@@ -1,0 +1,10 @@
+{
+  "info": {
+    "title": "Composite Bool Int",
+    "description": "Composite Swagger Client that represents merging body boolean and body integer swagger clients"
+  },
+  "documents": [
+    "./body-boolean.quirks.json",
+    "./body-integer.json"
+  ]
+}

--- a/swagger/httpInfrastructure.quirks.json
+++ b/swagger/httpInfrastructure.quirks.json
@@ -1,0 +1,2828 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "AutoRest Http Infrastructure Test Service",
+    "description": "Test Infrastructure for AutoRest",
+    "version": "1.0.0"
+  },
+  "host": "localhost",
+  "schemes": [
+    "http"
+  ],
+  "produces": [ "application/json" ],
+  "consumes": [ "application/json" ],
+  "paths": {
+    "/http/failure/emptybody/error": {
+      "get": {
+        "operationId": "httpFailure_getEmptyError",
+        "description": "Get empty error form server",
+        "tags": [
+          "HttpFailure Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returns 400 error code with the get request",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean",
+              "enum": [ true ]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/nomodel/error": {
+      "get": {
+        "operationId": "httpFailure_getNoModelError",
+        "description": "Get empty error form server",
+        "tags": [
+          "HttpFailure Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returns 400 error code with the get request",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean",
+              "enum": [ true ]
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/nomodel/empty": {
+      "get": {
+        "operationId": "httpFailure_getNoModelEmpty",
+        "description": "Get empty response from server",
+        "tags": [
+          "HttpFailure Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returns 200 error code with the get request",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean",
+              "enum": [ true ]
+            }
+          }
+        }
+      }
+    },
+    "/http/success/200": {
+      "head": {
+        "operationId": "httpSuccess_head200",
+        "description": "Return 200 status code if successful",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the head request"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "httpSuccess_get200",
+        "description": "Get 200 success",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the get request",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean",
+              "enum": [ true ]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "options": {
+        "operationId": "httpSuccess_options200",
+        "description": "Options 200 success",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the options request",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean",
+              "enum": [ true ]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "httpSuccess_put200",
+        "description": "Put boolean value true returning 200 success",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "httpSuccess_patch200",
+        "description": "Patch true Boolean value in request returning 200",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "httpSuccess_post200",
+        "description": "Post bollean value true in request that returns a 200",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "httpSuccess_delete200",
+        "description": "Delete simple boolean value true returns 200",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/success/201": {
+      "put": {
+        "operationId": "httpSuccess_put201",
+        "description": "Put true Boolean value in request returns 201",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "httpSuccess_post201",
+        "description": "Post true Boolean value in request returns 201 (Created)",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/success/202": {
+      "put": {
+        "operationId": "httpSuccess_put202",
+        "description": "Put true Boolean value in request returns 202 (Accepted)",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "httpSuccess_patch202",
+        "description": "Patch true Boolean value in request returns 202",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "httpSuccess_post202",
+        "description": "Post true Boolean value in request returns 202 (Accepted)",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "httpSuccess_delete202",
+        "description": "Delete true Boolean value in request returns 202 (accepted)",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/success/204": {
+      "head": {
+        "operationId": "httpSuccess_head204",
+        "description": "Return 204 status code if successful",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully received the true boolean value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "httpSuccess_put204",
+        "description": "Put true Boolean value in request returns 204 (no content)",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "httpSuccess_patch204",
+        "description": "Patch true Boolean value in request returns 204 (no content)",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "HttpSuccess_post204",
+        "description": "Post true Boolean value in request returns 204 (no content)",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "httpSuccess_delete204",
+        "description": "Delete true Boolean value in request returns 204 (no content)",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/success/404": {
+      "head": {
+        "operationId": "httpSuccess_head404",
+        "description": "Return 404 status code",
+        "tags": [
+          "HttpSuccess Operations"
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully received the head request"
+          },
+          "404": {
+            "description": "Successfully received the head request"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/redirect/300": {
+      "head": {
+        "operationId": "httpRedirects_head300",
+        "description": "Return 300 status code and redirect to /http/success/200",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned afyter a successful redirect"
+          },
+          "300": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/head/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "httpRedirects_get300",
+        "description": "Return 300 status code and redirect to /http/success/200",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned afyter a successful redirect"
+          },
+          "300": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/get/200" ]
+              }
+            },
+            "schema": {
+              "description": "A list of location options for the request ['/http/success/get/200']",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/redirect/301": {
+      "head": {
+        "operationId": "httpRedirects_head301",
+        "description": "Return 301 status code and redirect to /http/success/200",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned afyter a successful redirect"
+          },
+          "301": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/head/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "httpRedirects_get301",
+        "description": "Return 301 status code and redirect to /http/success/200",
+        "tags": [
+          "HttpOperation Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned after a successful redirect"
+          },
+          "301": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/get/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "httpRedirects_put301",
+        "description": "Put true Boolean value in request returns 301.  This request should not be automatically redirected, but should return the received 301 to the caller for evaluation",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "301": {
+            "description": "Redirect to another endpoint. This redirect should *not* be automatically followed",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/failure/500" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/redirect/302": {
+      "head": {
+        "operationId": "httpRedirects_head302",
+        "description": "Return 302 status code and redirect to /http/success/200",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned afyter a successful redirect"
+          },
+          "302": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/head/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "httpRedirects_get302",
+        "description": "Return 302 status code and redirect to /http/success/200",
+        "tags": [
+          "HttpOperation Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned afyter a successful redirect"
+          },
+          "302": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/get/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "httpRedirects_patch302",
+        "description": "Patch true Boolean value in request returns 302.  This request should not be automatically redirected, but should return the received 302 to the caller for evaluation",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to another endpoint. This redirect should *not* be automatically followed",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/failure/500" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/redirect/303": {
+      "post": {
+        "operationId": "httpRedirects_post303",
+        "description": "Post true Boolean value in request returns 303.  This request should be automatically redirected usign a get, ultimately returning a 200 status code",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned afyter a successful redirect"
+          },
+          "303": {
+            "description": "Redirect to another endpoint. This redirect should be automatically followed with a get request",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/get/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/redirect/307": {
+      "head": {
+        "operationId": "httpRedirects_head307",
+        "description": "Redirect with 307, resulting in a 200 success",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned after a successful redirect"
+          },
+          "307": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/head/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "httpRedirects_get307",
+        "description": "Redirect get with 307, resulting in a 200 success",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned after a successful redirect"
+          },
+          "307": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/get/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "options": {
+        "operationId": "httpRedirects_options307",
+        "description": "options redirected with 307, resulting in a 200 after redirect",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned after a successful redirect"
+          },
+          "307": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/options/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "HttpRedirects_put307",
+        "description": "Put redirected with 307, resulting in a 200 after redirect",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned after a successful redirect"
+          },
+          "307": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/put/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "httpRedirects_patch307",
+        "description": "Patch redirected with 307, resulting in a 200 after redirect",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned after a successful redirect"
+          },
+          "307": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/patch/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "httpRedirects_post307",
+        "description": "Post redirected with 307, resulting in a 200 after redirect",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned after a successful redirect"
+          },
+          "307": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/post/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "httpRedirects_delete307",
+        "description": "Delete redirected with 307, resulting in a 200 after redirect",
+        "tags": [
+          "HttpRedirect Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success, should be returned after a successful redirect"
+          },
+          "307": {
+            "description": "Redirect to another endpoint",
+            "headers": {
+              "Location": {
+                "description": "The redirect location for this request",
+                "type": "string",
+                "enum": [ "/http/success/delete/200" ]
+              }
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/400": {
+      "head": {
+        "operationId": "httpClientFailure_head400",
+        "description": "Return 400 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "httpClientFailure_get400",
+        "description": "Return 400 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "options": {
+        "operationId": "httpClientFailure_options400",
+        "description": "Return 400 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "httpClientFailure_put400",
+        "description": "Return 400 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "httpClientFailure_patch400",
+        "description": "Return 400 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "httpClientFailure_post400",
+        "description": "Return 400 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "httpClientFailure_delete400",
+        "description": "Return 400 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/401": {
+      "head": {
+        "operationId": "httpClientFailure_head401",
+        "description": "Return 401 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/402": {
+      "get": {
+        "operationId": "httpClientFailure_get402",
+        "description": "Return 402 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/403": {
+      "options": {
+        "operationId": "httpClientFailure_options403",
+        "description": "Return 403 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "httpClientFailure_get403",
+        "description": "Return 403 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/404": {
+      "put": {
+        "operationId": "httpClientFailure_put404",
+        "description": "Return 404 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/405": {
+      "patch": {
+        "operationId": "httpClientFailure_patch405",
+        "description": "Return 405 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/406": {
+      "post": {
+        "operationId": "httpClientFailure_post406",
+        "description": "Return 406 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/407": {
+      "delete": {
+        "operationId": "httpClientFailure_delete407",
+        "description": "Return 407 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/409": {
+      "put": {
+        "operationId": "httpClientFailure_put409",
+        "description": "Return 409 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/410": {
+      "head": {
+        "operationId": "httpClientFailure_head410",
+        "description": "Return 410 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/411": {
+      "get": {
+        "operationId": "httpClientFailure_get411",
+        "description": "Return 411 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/412": {
+      "options": {
+        "operationId": "httpClientFailure_options412",
+        "description": "Return 412 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "httpClientFailure_get412",
+        "description": "Return 412 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/413": {
+      "put": {
+        "operationId": "httpClientFailure_put413",
+        "description": "Return 413 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/414": {
+      "patch": {
+        "operationId": "httpClientFailure_patch414",
+        "description": "Return 414 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/415": {
+      "post": {
+        "operationId": "httpClientFailure_post415",
+        "description": "Return 415 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/416": {
+      "get": {
+        "operationId": "httpClientFailure_get416",
+        "description": "Return 416 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/417": {
+      "delete": {
+        "operationId": "httpClientFailure_delete417",
+        "description": "Return 417 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/client/429": {
+      "head": {
+        "operationId": "httpClientFailure_head429",
+        "description": "Return 429 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpClientFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/server/501": {
+      "head": {
+        "operationId": "httpServerFailure_head501",
+        "description": "Return 501 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpServerFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "httpServerFailure_get501",
+        "description": "Return 501 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpServerFailure Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/failure/server/505": {
+      "post": {
+        "operationId": "httpServerFailure_post505",
+        "description": "Return 505 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpServerFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "httpServerFailure_delete505",
+        "description": "Return 505 status code - should be represented in the client as an error",
+        "tags": [
+          "HttpServerFailure Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/retry/408": {
+      "head": {
+        "operationId": "httpRetry_head408",
+        "description": "Return 408 status code, then 200 after retry",
+        "tags": [
+          "HttpRetry Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the true boolean value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/retry/500": {
+      "put": {
+        "operationId": "httpRetry_put500",
+        "description": "Return 500 status code, then 200 after retry",
+        "tags": [
+          "HttpRetry Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "httpRetry_patch500",
+        "description": "Return 500 status code, then 200 after retry",
+        "tags": [
+          "HttpRetry Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/retry/502": {
+      "get": {
+        "operationId": "httpRetry_get502",
+        "description": "Return 502 status code, then 200 after retry",
+        "tags": [
+          "HttpRetry Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the true boolean value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "options": {
+        "operationId": "httpRetry_options502",
+        "description": "Return 502 status code, then 200 after retry",
+        "tags": [
+          "HttpRetry Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the true boolean value",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean",
+              "enum": [ true ]
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/retry/503": {
+      "post": {
+        "operationId": "httpRetry_post503",
+        "description": "Return 503 status code, then 200 after retry",
+        "tags": [
+          "HttpRetry Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "httpRetry_delete503",
+        "description": "Return 503 status code, then 200 after retry",
+        "tags": [
+          "HttpRetry Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/retry/504": {
+      "put": {
+        "operationId": "httpRetry_put504",
+        "description": "Return 504 status code, then 200 after retry",
+        "tags": [
+          "HttpRetry Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "httpRetry_patch504",
+        "description": "Return 504 status code, then 200 after retry",
+        "tags": [
+          "HttpRetry Operations"
+        ],
+        "parameters": [
+          {
+            "name": "booleanValue",
+            "description": "Simple boolean value true",
+            "in": "body",
+            "schema": {
+              "description": "Simple boolean value true",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully received the boolean true value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/204/none/default/Error/response/200/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200Model204NoModelDefaultError200Valid",
+        "description": "Send a 200 response with valid payload: {'statusCode': '200'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "204": {
+            "description": "Return no payload"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/204/none/default/Error/response/204/none": {
+      "get": {
+        "operationId": "multipleResponses_get200Model204NoModelDefaultError204Valid",
+        "description": "Send a 204 response with no payload",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '204'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "204": {
+            "description": "Return no payload"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/204/none/default/Error/response/201/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200Model204NoModelDefaultError201Invalid",
+        "description": "Send a 201 response with valid payload: {'statusCode': '201'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "204": {
+            "description": "Return no payload"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/204/none/default/Error/response/202/none": {
+      "get": {
+        "operationId": "multipleResponses_get200Model204NoModelDefaultError202None",
+        "description": "Send a 202 response with no payload:",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "204": {
+            "description": "Return no payload"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/204/none/default/Error/response/400/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200Model204NoModelDefaultError400Valid",
+        "description": "Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "204": {
+            "description": "Return no payload"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/201/B/default/Error/response/200/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200Model201ModelDefaultError200Valid",
+        "description": "Send a 200 response with valid payload: {'statusCode': '200'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "201": {
+            "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
+            "schema": {
+              "$ref": "#/definitions/B"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/201/B/default/Error/response/201/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200Model201ModelDefaultError201Valid",
+        "description": "Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "201": {
+            "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
+            "schema": {
+              "$ref": "#/definitions/B"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/201/B/default/Error/response/400/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200Model201ModelDefaultError400Valid",
+        "description": "Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "201": {
+            "description": "Return {'statusCode': '201', 'textStatusCode': 'Created'}",
+            "schema": {
+              "$ref": "#/definitions/B"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/201/C/404/D/default/Error/response/200/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA201ModelC404ModelDDefaultError200Valid",
+        "description": "Send a 200 response with valid payload: {'statusCode': '200'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "201": {
+            "description": "Return {'httpCode': '201'}",
+            "schema": {
+              "$ref": "#/definitions/C"
+            }
+          },
+          "404": {
+            "description": "Return {'httpStatusCode': '404'}",
+            "schema": {
+              "$ref": "#/definitions/D"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/201/C/404/D/default/Error/response/201/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA201ModelC404ModelDDefaultError201Valid",
+        "description": "Send a 200 response with valid payload: {'httpCode': '201'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "201": {
+            "description": "Return {'httpCode': '201'}",
+            "schema": {
+              "$ref": "#/definitions/C"
+            }
+          },
+          "404": {
+            "description": "Return {'httpStatusCode': '404'}",
+            "schema": {
+              "$ref": "#/definitions/D"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/201/C/404/D/default/Error/response/404/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA201ModelC404ModelDDefaultError404Valid",
+        "description": "Send a 200 response with valid payload: {'httpStatusCode': '404'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "201": {
+            "description": "Return {'httpCode': '201'}",
+            "schema": {
+              "$ref": "#/definitions/C"
+            }
+          },
+          "404": {
+            "description": "Return {'httpStatusCode': '404'}",
+            "schema": {
+              "$ref": "#/definitions/D"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/201/C/404/D/default/Error/response/400/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA201ModelC404ModelDDefaultError400Valid",
+        "description": "Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          },
+          "201": {
+            "description": "Return {'httpCode': '201'}",
+            "schema": {
+              "$ref": "#/definitions/C"
+            }
+          },
+          "404": {
+            "description": "Return {'httpStatusCode': '404'}",
+            "schema": {
+              "$ref": "#/definitions/D"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/202/none/204/none/default/Error/response/202/none": {
+      "get": {
+        "operationId": "multipleResponses_get202None204NoneDefaultError202None",
+        "description": "Send a 202 response with no payload",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "202": {
+            "description": "No payload for Accepted"
+          },
+          "204": {
+            "description": "No Payload for NoContent"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/202/none/204/none/default/Error/response/204/none": {
+      "get": {
+        "operationId": "multipleResponses_get202None204NoneDefaultError204None",
+        "description": "Send a 204 response with no payload",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "202": {
+            "description": "No payload for Accepted"
+          },
+          "204": {
+            "description": "No Payload for NoContent"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/202/none/204/none/default/Error/response/400/valid": {
+      "get": {
+        "operationId": "multipleResponses_get202None204NoneDefaultError400Valid",
+        "description": "Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "202": {
+            "description": "No payload for Accepted"
+          },
+          "204": {
+            "description": "No Payload for NoContent"
+          },
+          "default": {
+            "description": "Unexpected error with payload: {'code': '400', 'message': 'client error'}",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/202/none/204/none/default/none/response/202/invalid": {
+      "get": {
+        "operationId": "multipleResponses_get202None204NoneDefaultNone202Invalid",
+        "description": "Send a 202 response with an unexpected payload {'property': 'value'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "202": {
+            "description": "No payload for Accepted, but this operation will return {'property': 'value'}"
+          },
+          "204": {
+            "description": "No payload for NoContent"
+          },
+          "default": {
+            "description": "Unexpected error with no payload"
+          }
+        }
+      }
+    },
+    "/http/payloads/202/none/204/none/default/none/response/204/none": {
+      "get": {
+        "operationId": "multipleResponses_get202None204NoneDefaultNone204None",
+        "description": "Send a 204 response with no payload",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "202": {
+            "description": "No payload for Accepted"
+          },
+          "204": {
+            "description": "No payload for NoContent"
+          },
+          "default": {
+            "description": "Unexpected error with no payload"
+          }
+        }
+      }
+    },
+    "/http/payloads/202/none/204/none/default/none/response/400/none": {
+      "get": {
+        "operationId": "multipleResponses_get202None204NoneDefaultNone400None",
+        "description": "Send a 400 response with no payload",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "202": {
+            "description": "No payload for Accepted"
+          },
+          "204": {
+            "description": "No payload for NoContent"
+          },
+          "default": {
+            "description": "Unexpected error with no payload"
+          }
+        }
+      }
+    },
+    "/http/payloads/202/none/204/none/default/none/response/400/invalid": {
+      "get": {
+        "operationId": "multipleResponses_get202None204NoneDefaultNone400Invalid",
+        "description": "Send a 400 response with an unexpected payload {'property': 'value'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "202": {
+            "description": "No payload for Accepted"
+          },
+          "204": {
+            "description": "No payload for NoContent"
+          },
+          "default": {
+            "description": "Unexpected error should have no payload, but this operation sends: {'property': 'value'}"
+          }
+        }
+      }
+    },
+    "/http/payloads/default/A/response/200/valid": {
+      "get": {
+        "operationId": "multipleResponses_getDefaultModelA200Valid",
+        "description": "Send a 200 response with valid payload: {'statusCode': '200'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Return {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/default/A/response/200/none": {
+      "get": {
+        "operationId": "multipleResponses_getDefaultModelA200None",
+        "description": "Send a 200 response with no payload",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Return no payload",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/default/A/response/400/valid": {
+      "get": {
+        "operationId": "multipleResponses_getDefaultModelA400Valid",
+        "description": "Send a 400 response with valid payload: {'statusCode': '400'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Return {'statusCode': '400'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/default/A/response/400/none": {
+      "get": {
+        "operationId": "multipleResponses_getDefaultModelA400None",
+        "description": "Send a 400 response with no payload",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Return no payload",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/default/none/response/200/invalid": {
+      "get": {
+        "operationId": "multipleResponses_getDefaultNone200Invalid",
+        "description": "Send a 200 response with invalid payload: {'statusCode': '200'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Return invalid payload {'statusCode': '200'}"
+          }
+        }
+      }
+    },
+    "/http/payloads/default/none/response/200/none": {
+      "get": {
+        "operationId": "multipleResponses_getDefaultNone200None",
+        "description": "Send a 200 response with no payload",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Return no payload"
+          }
+        }
+      }
+    },
+    "/http/payloads/default/none/response/400/invalid": {
+      "get": {
+        "operationId": "multipleResponses_getDefaultNone400Invalid",
+        "description": "Send a 400 response with valid payload: {'statusCode': '400'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Return invalid payload{'statusCode': '400'}"
+          }
+        }
+      }
+    },
+    "/http/payloads/default/none/response/400/none": {
+      "get": {
+        "operationId": "multipleResponses_getDefaultNone400None",
+        "description": "Send a 400 response with no payload",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "default": {
+            "description": "Return no payload"
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/response/200/none": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA200None",
+        "description": "Send a 200 response with no payload, when a payload is expected - client should return a null object of thde type for model A",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return no payload",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/response/200/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA200Valid",
+        "description": "Send a 200 response with payload {'statusCode': '200'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return a respose with valid payload {'statusCode': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/response/200/invalid": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA200Invalid",
+        "description": "Send a 200 response with invalid payload {'statusCodeInvalid': '200'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return a respose with invalid payload {'statusCodeInvalid': '200'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/response/400/none": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA400None",
+        "description": "Send a 400 response with no payload client should treat as an http error with no error model",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return no payload, and an unmodeled 400 response",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/response/400/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA400Valid",
+        "description": "Send a 200 response with payload {'statusCode': '400'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return a respose with valid payload {'statusCode': '400'}  but error status code 400, which is unmodeled",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/response/400/invalid": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA400Invalid",
+        "description": "Send a 200 response with invalid payload {'statusCodeInvalid': '400'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return a respose with invalid payload {'statusCodeInvalid': '400'}",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    },
+    "/http/payloads/200/A/response/202/valid": {
+      "get": {
+        "operationId": "multipleResponses_get200ModelA202Valid",
+        "description": "Send a 202 response with payload {'statusCode': '202'}",
+        "tags": [
+          "MultipleResponse Operations"
+        ],
+        "responses": {
+          "200": {
+            "description": "Return a respose with valid payload {'statusCode': '202'}  but unmodeled success status code 202, which is unmodeled",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "properties": {
+        "status": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "A": {
+      "x-ms-client-name": {
+        "name": "MyException"
+      },
+      "properties": {
+        "statusCode": {
+          "type": "string"
+        }
+      }
+    },
+    "B": {
+      "allOf": [
+        { "$ref": "#/definitions/A" }
+      ],
+      "properties": {
+        "textStatusCode": {
+          "type": "string"
+        }
+      }
+    },
+    "C": {
+      "properties": {
+        "httpCode": {
+          "type": "string"
+        }
+      }
+    },
+    "D": {
+      "properties": {
+        "httpStatusCode": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
after fixing [this](https://github.com/Azure/autorest/issues/2689), some tests now generate different code (that was probably the intention all along! how did no one notice?)

Since that new/correct code will "break" existing acceptance tests if a generator targets the modeler *with* the fix for the above issue, this PR provides "backwards-compatible"/quirky versions of the affected Swaggers. So instead of fixing up the acceptance tests, generator owners can quickly target the quirky swaggers in their `regeneration.iced` files and everything will keep working.