### PR TITLE
Add stop script for cross-plat termination of HTTP server.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "scripts": {
     "start": "node ./startup/www",
+    "stop": "node ./startup/shutdown.js",
     "testci": "echo no tests",
     "publish-preview": "npm publish"
   },
@@ -21,6 +22,8 @@
     "express": "~4.13.4",
     "jade": "~1.11.0",
     "serve-favicon": "~2.3.0",
+    "socket.io-client": "~2.0.4",
+    "socket.io": "~2.0.4",
     "underscore": "*",
     "morgan": "1.6.1"
   }

--- a/startup/shutdown.js
+++ b/startup/shutdown.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+/**
+ * Module dependencies.
+ */
+var io = require('socket.io-client');
+var Constants = require('../util/constants.js')
+
+/**
+ * Get HTTP server port and socket client.
+ */
+var port = process.env.PORT || Constants.DEFAULT_SERVER_PORT;
+var socketClient = io.connect('http://localhost:' + port);
+
+/**
+ * Send the npmStop signal to the server process.
+ */
+socketClient.on('connect', () => {
+  socketClient.emit('npmStop');
+  setTimeout(() => {
+    process.exit(0);
+  }, 1000);
+});

--- a/startup/www.js
+++ b/startup/www.js
@@ -31,6 +31,17 @@ server.on('error', onError);
 server.on('listening', onListening);
 
 /**
+ * Listen on a socket for the npmStop signal, this will terminate the HTTP server.
+ */
+let io = require('socket.io')(server);
+io.on('connection', (socketServer) => {
+  socketServer.on('npmStop', () => {
+    console.log('Received npmStop signal, server will exit');
+    process.exit(0);
+  });
+});
+
+/**
  * Normalize a port into a number, string, or false.
  */
 


### PR DESCRIPTION
With this script one can "npm stop" to terminate the test HTTP server.
It works by using a local socket as an RPC mechanism.  When the server
starts it will open a socket listening for message "npmStop" which when
received will terminate the test server process.  The stop script will
send the "npmStop" message.