### PR TITLE
Update scheme and host for usability

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -7,7 +7,7 @@
     },
     "host": "management.azure.com",
     "schemes": [
-        "http"
+        "https"
     ],
     "produces": [ "application/json", "text/plain", "text/html"],
     "consumes": [ "application/json", "text/plain", "text/html"],

--- a/swagger.json
+++ b/swagger.json
@@ -7,7 +7,7 @@
     },
     "host": "management.azure.com",
     "schemes": [
-        "https"
+        "http"
     ],
     "produces": [ "application/json", "text/plain", "text/html"],
     "consumes": [ "application/json", "text/plain", "text/html"],

--- a/swagger/azure-parameter-grouping.json
+++ b/swagger/azure-parameter-grouping.json
@@ -7,7 +7,7 @@
   },
   "host": "localhost",
   "schemes": [
-    "https"
+    "http"
   ],
   "produces": [
     "application/json"

--- a/swagger/azure-parameter-grouping.json
+++ b/swagger/azure-parameter-grouping.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/azure-report.json
+++ b/swagger/azure-report.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/azure-resource-x.json
+++ b/swagger/azure-resource-x.json
@@ -5,7 +5,7 @@
     "description": "Resource Flattening for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/azure-resource.json
+++ b/swagger/azure-resource.json
@@ -5,7 +5,7 @@
     "description": "Resource Flattening for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/azure-special-properties.json
+++ b/swagger/azure-special-properties.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "2015-07-01-preview"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-array.json
+++ b/swagger/body-array.json
@@ -5,7 +5,7 @@
         "description": "Test Infrastructure for AutoRest Swagger BAT",
         "version": "1.0.0"
     },
-    "host": "localhost",
+    "host": "localhost:3000",
     "schemes": [
         "http"
     ],

--- a/swagger/body-boolean.json
+++ b/swagger/body-boolean.json
@@ -5,7 +5,7 @@
         "description": "Test Infrastructure for AutoRest",
         "version": "1.0.0"
     },
-    "host": "localhost",
+    "host": "localhost:3000",
     "schemes": [
         "http"
     ],

--- a/swagger/body-boolean.quirks.json
+++ b/swagger/body-boolean.quirks.json
@@ -5,7 +5,7 @@
         "description": "Test Infrastructure for AutoRest",
         "version": "1.0.0"
     },
-    "host": "localhost",
+    "host": "localhost:3000",
     "schemes": [
         "http"
     ],

--- a/swagger/body-byte.json
+++ b/swagger/body-byte.json
@@ -5,7 +5,7 @@
         "description": "Test Infrastructure for AutoRest Swagger BAT",
         "version": "1.0.0"
     },
-    "host": "localhost",
+    "host": "localhost:3000",
     "schemes": [
         "http"
     ],

--- a/swagger/body-complex.json
+++ b/swagger/body-complex.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "2016-02-29"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-date.json
+++ b/swagger/body-date.json
@@ -7,7 +7,7 @@
   },
   "host": "localhost",
   "schemes": [
-    "https"
+    "http"
   ],
   "produces": [
     "application/json"

--- a/swagger/body-date.json
+++ b/swagger/body-date.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-datetime-rfc1123.json
+++ b/swagger/body-datetime-rfc1123.json
@@ -7,7 +7,7 @@
   },
   "host": "localhost",
   "schemes": [
-    "https"
+    "http"
   ],
   "produces": [
     "application/json"

--- a/swagger/body-datetime-rfc1123.json
+++ b/swagger/body-datetime-rfc1123.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-datetime.json
+++ b/swagger/body-datetime.json
@@ -7,7 +7,7 @@
   },
   "host": "localhost",
   "schemes": [
-    "https"
+    "http"
   ],
   "produces": [
     "application/json"

--- a/swagger/body-datetime.json
+++ b/swagger/body-datetime.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-dictionary.json
+++ b/swagger/body-dictionary.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest Swagger BAT",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-duration.json
+++ b/swagger/body-duration.json
@@ -7,7 +7,7 @@
   },
   "host": "localhost",
   "schemes": [
-    "https"
+    "http"
   ],
   "produces": [
     "application/json"

--- a/swagger/body-duration.json
+++ b/swagger/body-duration.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-file.json
+++ b/swagger/body-file.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest Swagger BAT",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-formdata.json
+++ b/swagger/body-formdata.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest Swagger BAT",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-integer.json
+++ b/swagger/body-integer.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-number.json
+++ b/swagger/body-number.json
@@ -7,7 +7,7 @@
   },
   "host": "localhost",
   "schemes": [
-    "https"
+    "http"
   ],
   "produces": [
     "application/json"

--- a/swagger/body-number.json
+++ b/swagger/body-number.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-number.quirks.json
+++ b/swagger/body-number.quirks.json
@@ -7,7 +7,7 @@
   },
   "host": "localhost",
   "schemes": [
-    "https"
+    "http"
   ],
   "produces": [
     "application/json"

--- a/swagger/body-number.quirks.json
+++ b/swagger/body-number.quirks.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-string.json
+++ b/swagger/body-string.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest Swagger BAT",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/body-string.quirks.json
+++ b/swagger/body-string.quirks.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest Swagger BAT",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/complex-model.json
+++ b/swagger/complex-model.json
@@ -5,7 +5,7 @@
     "description": "Some cool documentation.",
     "version": "2014-04-01-preview"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/extensible-enums-swagger.json
+++ b/swagger/extensible-enums-swagger.json
@@ -5,7 +5,7 @@
   "title": "PetStore Inc",
   "description": "PetStore"
  },
- "host": "localhost",
+ "host": "localhost:3000",
  "schemes": [
   "http"
  ],

--- a/swagger/extensible-enums-swagger.json
+++ b/swagger/extensible-enums-swagger.json
@@ -7,7 +7,7 @@
  },
  "host": "localhost",
  "schemes": [
-  "https"
+  "http"
  ],
  "paths": {
   "/extensibleenums/pet/{petId}": {

--- a/swagger/head-exceptions.json
+++ b/swagger/head-exceptions.json
@@ -5,7 +5,7 @@
         "description": "Test Infrastructure for AutoRest",
         "version": "1.0.0"
     },
-    "host": "localhost",
+    "host": "localhost:3000",
     "schemes": [
         "http"
     ],

--- a/swagger/head.json
+++ b/swagger/head.json
@@ -5,7 +5,7 @@
         "description": "Test Infrastructure for AutoRest",
         "version": "1.0.0"
     },
-    "host": "localhost",
+    "host": "localhost:3000",
     "schemes": [
         "http"
     ],

--- a/swagger/header.json
+++ b/swagger/header.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/httpInfrastructure.json
+++ b/swagger/httpInfrastructure.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/httpInfrastructure.quirks.json
+++ b/swagger/httpInfrastructure.quirks.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/lro.json
+++ b/swagger/lro.json
@@ -5,7 +5,7 @@
     "description": "Long-running Operation for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/model-flattening.json
+++ b/swagger/model-flattening.json
@@ -5,7 +5,7 @@
     "description": "Resource Flattening for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -5,7 +5,7 @@
     "description": "Long-running Operation for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/parameter-flattening.json
+++ b/swagger/parameter-flattening.json
@@ -8,7 +8,7 @@
       "ft": 2
     }
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/report.json
+++ b/swagger/report.json
@@ -5,7 +5,7 @@
         "description": "Test Infrastructure for AutoRest",
         "version": "1.0.0"
     },
-    "host": "localhost",
+    "host": "localhost:3000",
     "schemes": [
         "http"
     ],

--- a/swagger/required-optional.json
+++ b/swagger/required-optional.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/storage.json
+++ b/swagger/storage.json
@@ -6,7 +6,7 @@
   },
   "host": "management.azure.com",
   "schemes": [
-    "https"
+    "http"
   ],
   "consumes": [
     "application/json",

--- a/swagger/storage.json
+++ b/swagger/storage.json
@@ -6,7 +6,7 @@
   },
   "host": "management.azure.com",
   "schemes": [
-    "http"
+    "https"
   ],
   "consumes": [
     "application/json",

--- a/swagger/subscriptionId-apiVersion.json
+++ b/swagger/subscriptionId-apiVersion.json
@@ -7,7 +7,7 @@
   },
   "host": "management.azure.com",
   "schemes": [
-    "http"
+    "https"
   ],
   "basePath": "/",
   "produces": [ "application/json" ],

--- a/swagger/subscriptionId-apiVersion.json
+++ b/swagger/subscriptionId-apiVersion.json
@@ -7,7 +7,7 @@
   },
   "host": "management.azure.com",
   "schemes": [
-    "https"
+    "http"
   ],
   "basePath": "/",
   "produces": [ "application/json" ],

--- a/swagger/url-multi-collectionFormat.json
+++ b/swagger/url-multi-collectionFormat.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/url.json
+++ b/swagger/url.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],

--- a/swagger/validation.json
+++ b/swagger/validation.json
@@ -5,7 +5,7 @@
     "description": "Test Infrastructure for AutoRest. No server backend exists for these tests.",
     "version": "1.0.0"
   },
-  "host": "localhost",
+  "host": "localhost:3000",
   "schemes": [
     "http"
   ],


### PR DESCRIPTION
1. Doing SSL on localhost requires some certificate setup that I doubt anyone is doing in their dev environment. This changes it so that when code generators create base URLs for the test services, they'll all be http://localhost instead of some being http://localhost and others being https://localhost.

2. The testserver runs on port 3000 by default, so I added a port specifier to the host in each test Swagger as per OpenAPI 2 spec https://swagger.io/docs/specification/2-0/api-host-and-base-path/
