### PR TITLE
Revert "Removing modelAsExtensible"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.3.15",
+  "version": "2.3.14",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",

--- a/swagger/body-complex.json
+++ b/swagger/body-complex.json
@@ -1179,8 +1179,7 @@
           "enum": [ "cyan", "Magenta", "YELLOW", "blacK" ],
           "x-ms-enum": {
             "name": "CMYKColors",
-            "modelAsString": true,
-            "oldModelAsString": true
+            "modelAsString": true
           }
         }
       }

--- a/swagger/extensible-enums-swagger.json
+++ b/swagger/extensible-enums-swagger.json
@@ -83,7 +83,7 @@
      ],
      "x-ms-enum": {
       "name": "DaysOfWeekExtensibleEnum",
-      "modelAsString": true
+      "modelAsExtensible": true
      },
      "default": "Friday"
     },
@@ -97,6 +97,7 @@
      ],
      "x-ms-enum": {
       "modelAsString": true,
+      "modelAsExtensible": true,
       "name": "IntEnum",
       "values": [
        {


### PR DESCRIPTION
Reverts Azure/autorest.testserver#35

Reverting since this breaks regeneration tests in all generator/modeler repos (have to publish AutoRest as well/first to unblock those!)