### PR TITLE
Enable CORS. Fix path separator in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
         "type": "node",
         "request": "launch",
         "name": "Start Server",
-        "program": "${workspaceRoot}\\startup\\www.js",
+        "program": "${workspaceRoot}/startup/www.js",
         "env": {
           "PORT": "3000"
         }

--- a/app.js
+++ b/app.js
@@ -41,6 +41,7 @@ var errorStatusCodes = require('./routes/errorStatusCodes.js');
 var additionalProperties = require('./routes/additionalProperties.js');
 var xml = require('./routes/xml.js'); // XML serialization
 var util = require('util');
+var cors = require('cors');
 var app = express();
 
 //set up server log
@@ -53,6 +54,13 @@ if (!fs.existsSync(testResultDir)) {
 }
 var logfile = fs.createWriteStream(path.join(testResultDir, logFileName), {flags: 'a'});
 app.use(morgan('combined', {stream: logfile}));
+
+// allow CORS for browser tests
+app.use(cors({
+  origin: /localhost:\d+/,
+  credentials: true,
+  exposedHeaders: ["x-ms-request-id", "foo-request-id", "Content-Type", "value", "Location", "Azure-AsyncOperation", "Retry-After"]
+}));
 
 var azurecoverage = {};
 var optionalCoverage = {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "body-parser": "~1.15.1",
     "busboy": "*",
     "cookie-parser": "~1.4.1",
+    "cors": "^2.8.4",
     "debug": "~2.2.0",
     "express": "~4.13.4",
     "jade": "~1.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Uses an OS-agnostic path separator in launch.json
- Adds the cors middleware package which lets us do browser testing in autorest.typescript