### PR TITLE
Remove mixed ref and xml/name

### DIFF
--- a/swagger/xml-service.json
+++ b/swagger/xml-service.json
@@ -785,9 +785,6 @@
         "Metadata": {
           "$ref": "#/definitions/Metadata"
         }
-      },
-      "xml": {
-        "name": "Container"
       }
     },
     "ContainerProperties": {

--- a/swagger/xml-service.json
+++ b/swagger/xml-service.json
@@ -671,6 +671,9 @@
             }
           }
         }
+      },
+      "xml": {
+        "name": "slide"
       }
     },
     "Slideshow": {
@@ -701,10 +704,7 @@
         "slides": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Slide",
-            "xml": {
-              "name": "slide"
-            }
+            "$ref": "#/definitions/Slide"
           }
         }
       }
@@ -785,6 +785,9 @@
         "Metadata": {
           "$ref": "#/definitions/Metadata"
         }
+      },
+      "xml": {
+        "name": "Container"
       }
     },
     "ContainerProperties": {
@@ -851,10 +854,7 @@
           },
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Container",
-            "xml": {
-              "name": "Container"
-            }
+            "$ref": "#/definitions/Container"
           }
         },
         "NextMarker": {
@@ -894,6 +894,9 @@
           "type": "integer",
           "minimum": 0
         }
+      },
+      "xml": {
+        "name": "CorsRule"
       }
     },
     "Blob": {
@@ -921,6 +924,9 @@
         "Metadata": {
           "$ref": "#/definitions/Metadata"
         }
+      },
+      "xml": {
+        "name": "Blob"
       }
     },
     "BlobProperties": {
@@ -1155,10 +1161,7 @@
         "Blob": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Blob",
-            "xml": {
-              "name": "Blob"
-            }
+            "$ref": "#/definitions/Blob"
           }
         }
       }
@@ -1323,16 +1326,16 @@
           "description": "The access policy",
           "$ref": "#/definitions/AccessPolicy"
         }
-      }
+      },
+      "xml": {
+        "name": "SignedIdentifier"
+      }    
     },
     "SignedIdentifiers": {
       "description": "a collection of signed identifiers",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/SignedIdentifier",
-        "xml": {
-          "name": "SignedIdentifier"
-        }
+        "$ref": "#/definitions/SignedIdentifier"
       },
       "xml": {
         "wrapped": true,
@@ -1359,10 +1362,7 @@
           "description": "The set of CORS rules.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/CorsRule",
-            "xml": {
-              "name": "CorsRule"
-            }
+            "$ref": "#/definitions/CorsRule"
           },
           "xml": {
             "wrapped": true


### PR DESCRIPTION
@fearthecowboy @RikkiGibson This is what we discussed, Swagger does not allow having $ref and XML/Name at the same time, and we should not support it.
That's an easy fix that is completely iso-functional and will generate exactly the same thing, but following Swagger recommendation :). There is already enough trouble with the XML spec in Swagger, to create ourselves more trouble with invalid syntax ;)

Note that we must update the official Storage Swagger for DataPlane with that, and I would be surprised that anyone has a trouble with that, the message is really "Please update this way, that's the same thing, but at least it's valid Swagger". I didn't find this spec on the RestAPI specs repo, I don't what Go guys are using to generate the SDK.