### PR TITLE
Make ID payload data type match the swagger definition.

### DIFF
--- a/routes/lros.js
+++ b/routes/lros.js
@@ -633,7 +633,7 @@ var lros = function (coverage) {
   router.get('/post/payload/200', function (req, res, next) {
     var scenario = 'LROPost200';
     coverage[scenario]++;
-    res.status(200).end('{"id":1, "name":"product"}');
+    res.status(200).end('{"id":"1", "name":"product"}');
   });
 
   coverage['LROPostAsyncRetrySucceeded'] = 0;


### PR DESCRIPTION
The swagger defines ID as string but the test server was returning an
integer which breaks Go.  Changed return type to string to match.