### PR TITLE
Add endpoint for XML headers method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.5.17",
+  "version": "2.5.18",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",

--- a/routes/xml.js
+++ b/routes/xml.js
@@ -496,6 +496,11 @@ var xmlService = function () {
     expectXmlBody(req, res, complexTypeRefComplexTypeWithXMLmeta);
   });
 
+  router.get('/headers', function (req, res) {
+    res.status(200);
+    res.setHeader("Custom-HEADER", "custom-value");
+    res.end();
+  });
 };
 
 xmlService.prototype.router = router;


### PR DESCRIPTION
This was actually in the Swagger but I somehow never created the route for it. This is meant to exercise custom response headers and case insensitivity to make sure there are no bad interactions with the XML code paths in each language runtime. There's no actual XML sent or received.