### PR TITLE
Don't publish test results

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,6 +9,7 @@ tools/
 tasks/
 scripts/
 gruntfile.js
+TestResults/
 
 # Nuget packages #
 .nuget/
@@ -17,3 +18,4 @@ packages.config
 
 # VS #
 .ntvs_analysis.*
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.5.18",
+  "version": "2.5.19",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The package for 2.5.18 was over 100 MB uncompressed because my local test results were all included in the package.. Let's not do that.