### PR TITLE
Remove remaining property xml names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.5.19",
+  "version": "2.5.20",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",

--- a/swagger/xml-service.json
+++ b/swagger/xml-service.json
@@ -327,10 +327,7 @@
                 "wrapped": true
               },
               "items": {
-                "$ref": "#/definitions/Banana",
-                "xml": {
-                  "name": "banana"
-                }
+                "$ref": "#/definitions/Banana"
               }
             },
             "required": true
@@ -382,10 +379,7 @@
                 "wrapped": true
               },
               "items": {
-                "$ref": "#/definitions/Banana",
-                "xml": {
-                  "name": "banana"
-                }
+                "$ref": "#/definitions/Banana"
               }
             },
             "required": true
@@ -437,10 +431,7 @@
                 "wrapped": true
               },
               "items": {
-                "$ref": "#/definitions/Banana",
-                "xml": {
-                  "name": "banana"
-                }
+                "$ref": "#/definitions/Banana"
               }
             },
             "required": true
@@ -464,10 +455,7 @@
           "200": {
             "description": "The unknown banana.",
             "schema": {
-              "$ref": "#/definitions/Banana",
-              "xml": {
-                "name": "banana"
-              }
+              "$ref": "#/definitions/Banana"
             }
           }
         }


### PR DESCRIPTION
This actually turned out to not be many places where we still used this way. Banana here has an xml name on the model definition already.