### PR TITLE
Xml parse failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.5.24",
+  "version": "2.5.25",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",

--- a/routes/xml.js
+++ b/routes/xml.js
@@ -13,8 +13,14 @@ var expectXmlBody = function (req, res, body) {
   req.setEncoding('utf8');
   req.on('data', function(chunk) { rawBody += chunk });
   req.on('end', async function() {
-    var actualParsedBody = await parseXMLString(rawBody);
-    var expectedParsedBody = await parseXMLString(body);
+    var actualParsedBody, expectedParsedBody;
+    try {
+      actualParsedBody = await parseXMLString(rawBody);
+      expectedParsedBody = await parseXMLString(body);
+    } catch (err) {
+      res.status(400).end("XML parse failure: " + err.message);
+      return;
+    }
 
     try {
       assert.deepStrictEqual(actualParsedBody, expectedParsedBody);


### PR DESCRIPTION
This gracefully handles the XML parse failure by responding with 400 instead of hanging.