### PR TITLE
Add AdditionalPropertiesSubclass fixture

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,6 +75,7 @@ var optionalCoverage = {
 };
 var coverage = {
   "additionalPropertiesTrue": 0,
+  "additionalPropertiesSubclass": 0,
   "additionalPropertiesTypeObject": 0,
   "additionalPropertiesTypeString": 0,
   "additionalPropertiesInProperties": 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.5.25",
+  "version": "2.6.0",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",

--- a/routes/additionalProperties.js
+++ b/routes/additionalProperties.js
@@ -13,6 +13,16 @@ var apTrue = {
   }
 };
 
+var apSubclass = {
+  id: 1,
+  name: 'Lisa',
+  friendly: true,
+  birthdate: '2017-12-13T02:29:51Z',
+  complexProperty: {
+    color: 'Red'
+  }
+};
+
 var apObject = {
   id: 2,
   name: 'Hira',
@@ -67,6 +77,16 @@ var additionalProperties = function (coverage) {
     if (req.body && _.isEqual(utils.coerceDate(req.body), apTrue)) {
         coverage["additionalPropertiesTrue"]++;
         let resBody = JSON.parse(JSON.stringify(apTrue));
+        resBody.status = true;
+        res.status(200).end(JSON.stringify(resBody));
+    } else {
+      utils.send400(res, next, "Did not like additionalProperties req " + util.inspect(req.body));
+    }
+  });
+  router.put('/true-subclass', function (req, res) {
+    if (req.body && _.isEqual(utils.coerceDate(req.body), apSubclass)) {
+        coverage["additionalPropertiesSubclass"]++;
+        let resBody = JSON.parse(JSON.stringify(apSubclass));
         resBody.status = true;
         res.status(200).end(JSON.stringify(resBody));
     } else {

--- a/swagger/additionalProperties.json
+++ b/swagger/additionalProperties.json
@@ -46,6 +46,36 @@
         }
       }
     },
+    "/additionalProperties/true-subclass": {
+      "put": {
+        "operationId": "Pets_CreateCatAPTrue",
+        "description": "Create a CatAPTrue which contains more properties than what is defined.",
+        "parameters": [
+          {
+            "name": "createParameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CatAPTrue"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A CatAPTrue which contains more properties than what is defined.",
+            "schema": {
+              "$ref": "#/definitions/CatAPTrue"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/additionalProperties/type/object": {
       "put": {
         "operationId": "Pets_CreateAPObject",
@@ -198,6 +228,19 @@
         }
       },
       "additionalProperties": true
+    },
+    "CatAPTrue": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/PetAPTrue"
+        }
+      ],
+      "properties": {
+        "friendly": {
+          "type": "boolean"
+        }
+      }
     },
     "PetAPObject": {
       "type": "object",


### PR DESCRIPTION
Adds test case for [de]serializing a subclass of a class with additionalProperties. This helps us test a case which currently doesn't work in node SDK according to user reports (related to graph IIRC)