### PR TITLE
Test for type that composes polymorphic object without explicit discriminator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",

--- a/routes/complex.js
+++ b/routes/complex.js
@@ -456,10 +456,102 @@ var complex = function (coverage) {
     'species': 'king',
   };
 
+  var dotFishMarketWithDiscriminator = {
+    'sampleSalmon': {
+      'fish.type': 'DotSalmon',
+      'location': 'sweden',
+      'iswild': false,
+      'species': 'king',
+    },
+    'salmons': [
+      {
+        'fish.type': 'DotSalmon',
+        'location': 'sweden',
+        'iswild': false,
+        'species': 'king',
+      },
+      {
+        'fish.type': 'DotSalmon',
+        'location': 'atlantic',
+        'iswild': true,
+        'species': 'king',
+      }
+    ],
+    'sampleFish': {
+      'fish.type': 'DotSalmon',
+      'location': 'australia',
+      'iswild': false,
+      'species': 'king',
+    },
+    'fishes': [
+      {
+        'fish.type': 'DotSalmon',
+        'location': 'australia',
+        'iswild': false,
+        'species': 'king',
+      },
+      {
+        'fish.type': 'DotSalmon',
+        'location': 'canada',
+        'iswild': true,
+        'species': 'king',
+      }
+    ]
+  }
+
+  var dotFishMarketWithoutDiscriminator = {
+    'sampleSalmon': {
+      'location': 'sweden',
+      'iswild': false,
+      'species': 'king',
+    },
+    'salmons': [
+      {
+        'location': 'sweden',
+        'iswild': false,
+        'species': 'king',
+      },
+      {
+        'location': 'atlantic',
+        'iswild': true,
+        'species': 'king',
+      }
+    ],
+    'sampleFish': {
+      'location': 'australia',
+      'iswild': false,
+      'species': 'king',
+    },
+    'fishes': [
+      {
+        'location': 'australia',
+        'iswild': false,
+        'species': 'king',
+      },
+      {
+        'location': 'canada',
+        'iswild': true,
+        'species': 'king',
+      }
+    ]
+  }
+
   coverage['getComplexPolymorphismDotSyntax'] = 0;
   router.get('/polymorphism/dotsyntax', function (req, res, next) {
     coverage['getComplexPolymorphismDotSyntax']++;
     res.status(200).end(JSON.stringify(dotSalmon));
+  });
+
+  coverage['getComposedWithDiscriminator'] = 0;
+  router.get('/polymorphism/composedWithDiscriminator', function (req, res, next) {
+    coverage['getComposedWithDiscriminator']++;
+    res.status(200).end(JSON.stringify(dotFishMarketWithDiscriminator));
+  });
+
+  coverage['getComposedWithoutDiscriminator'] = 0;
+  router.get('/polymorphism/composedWithoutDiscriminator', function (req, res, next) {
+    coverage['getComposedWithoutDiscriminator']++;
+    res.status(200).end(JSON.stringify(dotFishMarketWithoutDiscriminator));
   });
 
   router.put('/polymorphism/:scenario', function (req, res, next) {

--- a/swagger/body-complex.json
+++ b/swagger/body-complex.json
@@ -1010,7 +1010,7 @@
     "/complex/polymorphism/composedWithDiscriminator": {
       "get": {
         "operationId": "polymorphism_getComposedWithDiscriminator",
-        "description": "Get complex type composing a scalar polymorphic type and array of polymorphic type with discriminator specified",
+        "description": "Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.",
         "responses": {
           "200": {
             "description": "Returns an object that composes a scalar polymorphic object and array of polymorphic objects with discriminator specified",
@@ -1030,7 +1030,7 @@
     "/complex/polymorphism/composedWithoutDiscriminator": {
       "get": {
         "operationId": "polymorphism_getComposedWithoutDiscriminator",
-        "description": "Get complex type composing a scalar polymorphic type and array of polymorphic type without discriminator specified",
+        "description": "Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.",
         "responses": {
           "200": {
             "description": "Returns an object that composes a scalar polymorphic object and array of polymorphic objects without discriminator specified",

--- a/swagger/body-complex.json
+++ b/swagger/body-complex.json
@@ -1007,6 +1007,46 @@
         }
       }
     },
+    "/complex/polymorphism/composedWithDiscriminator": {
+      "get": {
+        "operationId": "polymorphism_getComposedWithDiscriminator",
+        "description": "Get complex type composing a scalar polymorphic type and array of polymorphic type with discriminator specified",
+        "responses": {
+          "200": {
+            "description": "Returns an object that composes a scalar polymorphic object and array of polymorphic objects with discriminator specified",
+            "schema": {
+              "$ref": "#/definitions/DotFishMarket"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/polymorphism/composedWithoutDiscriminator": {
+      "get": {
+        "operationId": "polymorphism_getComposedWithoutDiscriminator",
+        "description": "Get complex type composing a scalar polymorphic type and array of polymorphic type without discriminator specified",
+        "responses": {
+          "200": {
+            "description": "Returns an object that composes a scalar polymorphic object and array of polymorphic objects without discriminator specified",
+            "schema": {
+              "$ref": "#/definitions/DotFishMarket"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/complex/polymorphism/complicated": {
       "get": {
         "operationId": "polymorphism_getComplicated",
@@ -1333,6 +1373,27 @@
           "type": "boolean"
         }
       }
+    },
+    "DotFishMarket": {
+      "properties": {
+        "sampleSalmon": {
+          "$ref": "#/definitions/DotSalmon"
+        },
+        "salmons": {
+          "type": "array",
+          "items": {
+            "type": "#/definitions/DotSalmon"
+          }
+        },
+        "sampleFish": {
+          "$ref": "#/definitions/DotFish"
+        },
+        "fishes": {
+          "type": "array",
+          "items": {
+            "type": "#/definitions/DotFish"
+          }
+        }
     },
     "Fish": {
       "type":  "object",


### PR DESCRIPTION
Java deserialization was failing when it handles json string containing polymorphic object but without discriminator, in such cases deserializer should use the type specified in the model.

Test ensure this case is validated for both scalar and vector properties of a model.