### PR TITLE
Add an endpoint to get the current coverage results

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,6 +39,8 @@ var customUri = require('./routes/customUri.js');
 var extensibleEnums = require('./routes/extensibleEnums.js');
 var errorStatusCodes = require('./routes/errorStatusCodes.js');
 var additionalProperties = require('./routes/additionalProperties.js');
+var coverageEndpoint = require('./coverage/coverageEndpoint.js');
+
 var xml = require('./routes/xml.js'); // XML serialization
 var util = require('util');
 var cors = require('cors');
@@ -541,6 +543,7 @@ app.use('/extensibleEnums', new extensibleEnums(coverage).router);
 app.use('/errorStatusCodes', new errorStatusCodes(coverage).router);
 app.use('/additionalProperties', new additionalProperties(coverage).router);
 app.use('/xml', new xml(coverage).router);
+app.use('/coverage', new coverageEndpoint(coverage).router);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/coverage/coverageEndpoint.js
+++ b/coverage/coverageEndpoint.js
@@ -7,10 +7,10 @@ var coverageEndpoint = function(coverage) {
     });
 
     router.post("/clear", function(req, res, next) {
-        for (var property in Object.getOwnPropertyNames(coverage))
-        {
-            coverage[property] = 0;
-        }
+        Object.getOwnPropertyNames(coverage).forEach(function(val, idx, array) {
+            coverage[val] = 0;
+        });
+
         res.status(200).send();
     });
 }

--- a/coverage/coverageEndpoint.js
+++ b/coverage/coverageEndpoint.js
@@ -5,6 +5,14 @@ var coverageEndpoint = function(coverage) {
     router.get('/', function(req, res, next) {
         res.status(200).send(coverage);
     });
+
+    router.post("/clear", function(req, res, next) {
+        for (var property in Object.getOwnPropertyNames(coverage))
+        {
+            coverage[property] = 0;
+        }
+        res.status(200).send();
+    });
 }
 
 coverageEndpoint.prototype.router = router;

--- a/coverage/coverageEndpoint.js
+++ b/coverage/coverageEndpoint.js
@@ -1,0 +1,12 @@
+var express = require('express');
+var router = express.Router();
+
+var coverageEndpoint = function(coverage) {
+    router.get('/', function(req, res, next) {
+        res.status(200).send(coverage);
+    });
+}
+
+coverageEndpoint.prototype.router = router;
+
+module.exports = coverageEndpoint;

--- a/coverage/coverageEndpoint.js
+++ b/coverage/coverageEndpoint.js
@@ -3,15 +3,14 @@ var router = express.Router();
 
 var coverageEndpoint = function(coverage) {
     router.get('/', function(req, res, next) {
-        res.status(200).send(coverage);
+        res.status(200).send(coverage).end();
     });
 
     router.post("/clear", function(req, res, next) {
         Object.getOwnPropertyNames(coverage).forEach(function(val, idx, array) {
             coverage[val] = 0;
         });
-
-        res.status(200).send();
+        res.status(200).send().end();
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm setting up test infrastructure where we would start a server run a test and verify that it hit the expected endpoint. I need a way to query current coverage.

@lmazuel @fearthecowboy @MiYanni 