### PR TITLE
Add a success to all RequiredOptional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "main": "./startup/www.js",
   "repository": {
     "type": "git",

--- a/swagger/required-optional.json
+++ b/swagger/required-optional.json
@@ -53,6 +53,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -151,6 +154,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -202,6 +208,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -251,6 +260,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -300,6 +312,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -351,6 +366,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -400,6 +418,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -449,6 +470,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -500,6 +524,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -554,6 +581,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -608,6 +638,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -661,6 +694,9 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -709,6 +745,9 @@
         "operationId": "implicit_getRequiredGlobalPath",
         "description": "Test implicitly required path parameter",
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -728,6 +767,9 @@
         "operationId": "implicit_getRequiredGlobalQuery",
         "description": "Test implicitly required query parameter",
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {
@@ -747,6 +789,9 @@
         "operationId": "implicit_getOptionalGlobalQuery",
         "description": "Test implicitly optional query parameter",
         "responses": {
+          "200": {
+            "description": "Will not happen, request not supposed to be done."
+          },
           "default": {
             "description": "Unexpected error",
             "schema": {


### PR DESCRIPTION
For these operations, when implemented as tests, SDK should fail the client side validation and no calls should be done. The Swagger has been designed as a "All status code are failure" to try to represent that, which is unrealistic, and doesn't match any real life endpoint. This is adding 200 as ok scenario in order for code to generate something that makes sense.
Note that if the client-side validation doesn't work and the call is made, SDK will receive a 404, so the test will still receive an error from the server anyway. So doesn't change the actual behavior.