### PR TITLE
Add not-encoded authorized characters

### DIFF
--- a/legacy/routes/paths.js
+++ b/legacy/routes/paths.js
@@ -16,6 +16,7 @@ var scenarioMap = {
   "9999999.999": "Positive",
   "-9999999.999": "Negative",
   "begin!*'();:@ &=+$,/?#[]end": "UrlEncoded",
+  "begin!*'();:@&=+$,end": "UrlNonEncoded",
   "multibyte": "MultiByte",
   "empty": "Empty",
   "null": "Null",
@@ -99,7 +100,7 @@ var paths = function (coverage) {
 
     scenario = JSON.parse(scenario);
     wireParameter = JSON.parse(wireParameter);
-   
+
     if (test === null) {
       console.log("test was null\n");
       utils.send400(res, next, 'Unable to parse scenario \"\/paths\/' + type + '\/' + scenario + '\"');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/swagger/url.json
+++ b/swagger/url.json
@@ -376,6 +376,38 @@
         }
       }
     },
+    "/paths/string/begin!*'();:@&=+$,end/{stringPath}": {
+      "get": {
+        "operationId": "paths_stringUrlNonEncoded",
+        "description": "Get 'begin!*'();:@&=+$,end",
+        "summary": "https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded",
+        "tags": [
+          "Path Operations"
+        ],
+        "parameters": [
+          {
+            "name": "stringPath",
+            "in": "path",
+            "description": "'begin!*'();:@&=+$,end' url encoded string value",
+            "type": "string",
+            "enum": [ "begin!*'();:@&=+$,end" ],
+            "required": true,
+            "x-ms-skip-url-encoding": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully Received 'begin!*'();:@&=+$,end' url encoded string value"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
     "/paths/string/empty/{stringPath}": {
       "get": {
         "operationId": "paths_stringEmpty",


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc3986#appendix-A, any "pchar" is acceptable as the not-encoded form in the Swagger path.

Adding a test for that, since we got an issue with the Swagger of Storage tables that contains a single quote https://github.com/Azure/autorest.python/issues/242