### PR TITLE
Fix date comparison to allow ISO 8601 format

### DIFF
--- a/legacy/routes/datetime.js
+++ b/legacy/routes/datetime.js
@@ -69,6 +69,9 @@ var datetime = function(coverage, optionalCoverage) {
     });
 
     router.put('/min/:type', function(req, res, next) {
+        console.log(req.body);
+        console.log(new Date(req.body).toString());
+
         if (req.params.type === 'utc') {
             if (new Date(req.body).toString() === new Date('0001-01-01T00:00:00Z').toString()) {
                 coverage["putDateTimeMinUtc"]++;
@@ -77,7 +80,7 @@ var datetime = function(coverage, optionalCoverage) {
                 utils.send400(res, next, "Did not like the value provided for min datetime in the req " + util.inspect(req.body));
             }
         } else if (req.params.type === 'localpositiveoffset') {
-            if (req.body === '0001-01-01T10:00:00Z' || new Date(req.body).toString() === new Date('0001-01-01T00:00:00+14:00').toString()) {
+            if (req.body === '0001-01-01T10:00:00Z' || new Date(req.body).toISOString() === new Date('0001-01-01T10:00:00.000Z').toISOString()) {
                 optionalCoverage["putDateTimeMinLocalPositiveOffset"]++;
                 res.status(200).end();
             } else {

--- a/legacy/routes/datetime.js
+++ b/legacy/routes/datetime.js
@@ -69,9 +69,6 @@ var datetime = function(coverage, optionalCoverage) {
     });
 
     router.put('/min/:type', function(req, res, next) {
-        console.log(req.body);
-        console.log(new Date(req.body).toString());
-
         if (req.params.type === 'utc') {
             if (new Date(req.body).toString() === new Date('0001-01-01T00:00:00Z').toString()) {
                 coverage["putDateTimeMinUtc"]++;

--- a/legacy/routes/datetime.js
+++ b/legacy/routes/datetime.js
@@ -77,7 +77,7 @@ var datetime = function(coverage, optionalCoverage) {
                 utils.send400(res, next, "Did not like the value provided for min datetime in the req " + util.inspect(req.body));
             }
         } else if (req.params.type === 'localpositiveoffset') {
-            if (req.body === '0001-01-01T10:00:00Z' || new Date(req.body).toISOString() === new Date('0001-01-01T10:00:00.000Z').toISOString()) {
+            if (req.body === '0001-01-01T10:00:00Z' || req.body === '0001-01-01T10:00:00.000Z' || new Date(req.body).toString() === new Date('0001-01-01T00:00:00+14:00').toString()) {
                 optionalCoverage["putDateTimeMinLocalPositiveOffset"]++;
                 res.status(200).end();
             } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
Current version doesn't allow `0001-01-01T10:00:00.000Z`