### PR TITLE
Fix xms-response JSON return

### DIFF
--- a/legacy/routes/errorStatusCodes.js
+++ b/legacy/routes/errorStatusCodes.js
@@ -51,7 +51,7 @@ var pathitem = function(coverage) {
         if (whatAction === 'stay') {
             coverage['expectedNoErrors']++;
             res.status(200).end(JSON.stringify(tommyPet));
-        } 
+        }
         else if(whatAction === 'jump'){
             res.status(500).end(JSON.stringify(sadCasper));
             coverage['expectedPetSadError']++;
@@ -73,7 +73,7 @@ var pathitem = function(coverage) {
             res.status(200).end(JSON.stringify(tommyPet));
         }
         else if(petId === 'django') {
-            res.status(202).end('Processing request');
+            res.status(202).end();
         }
         else if(petId === 'coyoteUgly'){
             coverage['animalNotFoundError']++;
@@ -82,10 +82,10 @@ var pathitem = function(coverage) {
         else if(petId === 'weirdAlYankovic'){
             coverage['linkNotFoundError']++;
             res.status(404).end(JSON.stringify(linkNotFoundError));
-        } 
+        }
         else if(petId === 'ringo'){
             coverage['stringError']++;
-            res.status(400).end(petId+stringError);
+            res.status(400).end(JSON.stringify(petId+stringError));
         }
         else if(petId === 'alien123'){
             coverage['intError']++;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
XMS Error Swagger declares to produce JSON, so all routes should return valid JSON (or no body) otherwise the test doesn't make sense.