### PR TITLE
Fix coverage report

### DIFF
--- a/legacy/routes/datetime.js
+++ b/legacy/routes/datetime.js
@@ -71,7 +71,11 @@ var datetime = function(coverage, optionalCoverage) {
             coverage[scenario + "Lowercase"]++;
             ret = ret.toLowerCase();
         } else if (req.params.case === 'uppercase') {
-            coverage[scenario + "Uppercase"]++;
+            if (scenario == "getDateTimeMaxUtc7MS") {
+                optionalCoverage[scenario + "Uppercase"]++;
+            } else {
+                coverage[scenario + "Uppercase"]++;
+            }
             ret = ret.toUpperCase();
         } else {
             utils.send400(res, next, 'Please provide a valid case for datetime case ' +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
Made a mistake in 2.10.0 about coverage of `getDateTimeMaxUtc7MSUppercase`