### PR TITLE
Add JSON Content-Type to tests

### DIFF
--- a/legacy/routes/additionalProperties.js
+++ b/legacy/routes/additionalProperties.js
@@ -78,7 +78,7 @@ var additionalProperties = function (coverage) {
         coverage["additionalPropertiesTrue"]++;
         let resBody = JSON.parse(JSON.stringify(apTrue));
         resBody.status = true;
-        res.status(200).end(JSON.stringify(resBody));
+        res.status(200).json(resBody);
     } else {
       utils.send400(res, next, "Did not like additionalProperties req " + util.inspect(req.body));
     }
@@ -88,7 +88,7 @@ var additionalProperties = function (coverage) {
         coverage["additionalPropertiesSubclass"]++;
         let resBody = JSON.parse(JSON.stringify(apSubclass));
         resBody.status = true;
-        res.status(200).end(JSON.stringify(resBody));
+        res.status(200).json(resBody);
     } else {
       utils.send400(res, next, "Did not like additionalProperties req " + util.inspect(req.body));
     }
@@ -98,7 +98,7 @@ var additionalProperties = function (coverage) {
       coverage["additionalPropertiesTypeObject"]++;
       let resBody = JSON.parse(JSON.stringify(apObject));
       resBody.status = true;
-      res.status(200).end(JSON.stringify(resBody));
+      res.status(200).json(resBody);
     } else {
       utils.send400(res, next, "Did not like additionalProperties req " + util.inspect(req.body));
     }
@@ -108,7 +108,7 @@ var additionalProperties = function (coverage) {
       coverage["additionalPropertiesTypeString"]++;
       let resBody = JSON.parse(JSON.stringify(apString));
       resBody.status = true;
-      res.status(200).end(JSON.stringify(resBody));
+      res.status(200).json(resBody);
     } else {
       utils.send400(res, next, "Did not like additionalProperties req " + util.inspect(req.body));
     }
@@ -118,7 +118,7 @@ var additionalProperties = function (coverage) {
       coverage["additionalPropertiesInProperties"]++;
       let resBody = JSON.parse(JSON.stringify(apInProperties));
       resBody.status = true;
-      res.status(200).end(JSON.stringify(resBody));
+      res.status(200).json(resBody);
     } else {
       utils.send400(res, next, "Did not like additionalProperties req " + util.inspect(req.body));
     }
@@ -128,7 +128,7 @@ var additionalProperties = function (coverage) {
       coverage["additionalPropertiesInPropertiesWithAPTypeString"]++;
       let resBody = JSON.parse(JSON.stringify(apInPropertiesWithAPString));
       resBody.status = true;
-      res.status(200).end(JSON.stringify(resBody));
+      res.status(200).json(resBody);
     } else {
       utils.send400(res, next, "Did not like additionalProperties req " + util.inspect(req.body));
     }

--- a/legacy/routes/array.js
+++ b/legacy/routes/array.js
@@ -23,10 +23,10 @@ var array = function (coverage) {
       res.status(200).end();
     } else if (req.params.scenario === 'empty') {
       coverage['getArrayEmpty']++;
-      res.status(200).end('[]');
+      res.status(200).type('json').end('[]');
     } else if (req.params.scenario === 'invalid') {
       coverage['getArrayInvalid']++;
-      res.status(200).end('[1, 2, 3');
+      res.status(200).type('json').end('[1, 2, 3');
     } else {
       res.status(400).send('Request path must contain null or empty or invalid');
     }
@@ -37,142 +37,142 @@ var array = function (coverage) {
     if (req.params.type == 'boolean') {
       if (req.params.scenario === 'tfft') {
         coverage['getArrayBooleanValid']++;
-        res.status(200).end('[ true, false, false, true]');
+        res.status(200).type('json').end('[ true, false, false, true]');
       } else if (req.params.scenario === 'true.null.false') {
         coverage['getArrayBooleanWithNull']++;
-        res.status(200).end('[ true, null, false ]');
+        res.status(200).type('json').end('[ true, null, false ]');
       } else if (req.params.scenario === 'true.boolean.false') {
         coverage['getArrayBooleanWithString']++;
-        res.status(200).end('[true, \"boolean\", false]');
+        res.status(200).type('json').end('[true, \"boolean\", false]');
       } else {
         res.status(400).send('Request scenario for boolean primitive type must contain tfft or true.null.false or true.boolean.false');
       }
     } else if (req.params.type == 'integer') {
       if (req.params.scenario === '1.-1.3.300') {
         coverage['getArrayIntegerValid']++;
-        res.status(200).end('[ 1, -1, 3, 300]');
+        res.status(200).type('json').end('[ 1, -1, 3, 300]');
       } else if (req.params.scenario === '1.null.zero') {
         coverage['getArrayIntegerWithNull']++;
-        res.status(200).end('[ 1, null, 0 ]');
+        res.status(200).type('json').end('[ 1, null, 0 ]');
       } else if (req.params.scenario === '1.integer.0') {
         coverage['getArrayIntegerWithString']++;
-        res.status(200).end('[1, \"integer\", 0]');
+        res.status(200).type('json').end('[1, \"integer\", 0]');
       } else {
         res.status(400).send('Request scenario for integer primitive type must contain 1.-1.3.300 or 1.null.zero or 1.boolean.0');
       }
     } else if (req.params.type == 'long') {
       if (req.params.scenario === '1.-1.3.300') {
         coverage['getArrayLongValid']++;
-        res.status(200).end('[ 1, -1, 3, 300]');
+        res.status(200).type('json').end('[ 1, -1, 3, 300]');
       } else if (req.params.scenario === '1.null.zero') {
         coverage['getArrayLongWithNull']++;
-        res.status(200).end('[ 1, null, 0 ]');
+        res.status(200).type('json').end('[ 1, null, 0 ]');
       } else if (req.params.scenario === '1.integer.0') {
         coverage['getArrayLongWithString']++;
-        res.status(200).end('[1, \"integer\", 0]');
+        res.status(200).type('json').end('[1, \"integer\", 0]');
       } else {
         res.status(400).send('Request scenario for long primitive type must contain 1.-1.3.300 or 1.null.zero or 1.boolean.0');
       }
     } else if (req.params.type == 'float') {
       if (req.params.scenario === '0--0.01-1.2e20') {
         coverage['getArrayFloatValid']++;
-        res.status(200).end('[ 0, -0.01, -1.2e20]');
+        res.status(200).type('json').end('[ 0, -0.01, -1.2e20]');
       } else if (req.params.scenario === '0.0-null-1.2e20') {
         coverage['getArrayFloatWithNull']++;
-        res.status(200).end('[ 0.0, null, -1.2e20 ]');
+        res.status(200).type('json').end('[ 0.0, null, -1.2e20 ]');
       } else if (req.params.scenario === '1.number.0') {
         coverage['getArrayFloatWithString']++;
-        res.status(200).end('[1, \"number\", 0]');
+        res.status(200).type('json').end('[1, \"number\", 0]');
       } else {
         res.status(400).send('Request scenario for float primitive type must contain 0--0.01-1.2e20 or 0.0-null-1.2e20 or 1.number.0');
       }
     } else if (req.params.type == 'double') {
       if (req.params.scenario === '0--0.01-1.2e20') {
         coverage['getArrayDoubleValid']++;
-        res.status(200).end('[ 0, -0.01, -1.2e20]');
+        res.status(200).type('json').end('[ 0, -0.01, -1.2e20]');
       } else if (req.params.scenario === '0.0-null-1.2e20') {
         coverage['getArrayDoubleWithNull']++;
-        res.status(200).end('[ 0.0, null, -1.2e20 ]');
+        res.status(200).type('json').end('[ 0.0, null, -1.2e20 ]');
       } else if (req.params.scenario === '1.number.0') {
         coverage['getArrayDoubleWithString']++;
-        res.status(200).end('[1, \"number\", 0]');
+        res.status(200).type('json').end('[1, \"number\", 0]');
       } else {
         res.status(400).send('Request scenario for double primitive type must contain 0--0.01-1.2e20 or 0.0-null-1.2e20 or 1.number.0');
       }
     } else if (req.params.type == 'string') {
       if (req.params.scenario === 'foo1.foo2.foo3') {
         coverage['getArrayStringValid']++;
-        res.status(200).end('[ \"foo1\", \"foo2\", \"foo3\"]');
+        res.status(200).type('json').end('[ \"foo1\", \"foo2\", \"foo3\"]');
       } else if (req.params.scenario === 'foo.null.foo2') {
         coverage['getArrayStringWithNull']++;
-        res.status(200).end('[ \"foo\", null, \"foo2\" ]');
+        res.status(200).type('json').end('[ \"foo\", null, \"foo2\" ]');
       } else if (req.params.scenario === 'foo.123.foo2') {
         coverage['getArrayStringWithNumber']++;
-        res.status(200).end('[\"foo\", 123, \"foo2\"]');
+        res.status(200).type('json').end('[\"foo\", 123, \"foo2\"]');
       } else {
         res.status(400).send('Request scenario for string primitive type must contain foo1.foo2.foo3 or foo.null.foo2 or foo.123.foo2');
       }
     } else if (req.params.type == 'enum') {
       if (req.params.scenario === 'foo1.foo2.foo3') {
         coverage['getArrayEnumValid']++;
-        res.status(200).end('[ \"foo1\", \"foo2\", \"foo3\"]');
+        res.status(200).type('json').end('[ \"foo1\", \"foo2\", \"foo3\"]');
       } else {
         res.status(400).send('Request scenario for enum primitive type must contain foo1.foo2.foo3');
       }
     } else if (req.params.type == 'string-enum') {
       if (req.params.scenario === 'foo1.foo2.foo3') {
         coverage['getArrayStringEnumValid']++;
-        res.status(200).end('[ \"foo1\", \"foo2\", \"foo3\"]');
+        res.status(200).type('json').end('[ \"foo1\", \"foo2\", \"foo3\"]');
       } else {
         res.status(400).send('Request scenario for enum primitive type must contain foo1.foo2.foo3');
       }
     } else if (req.params.type == 'date') {
       if (req.params.scenario === 'valid') {
         coverage['getArrayDateValid']++;
-        res.status(200).end('[\"2000-12-01\", \"1980-01-02\", \"1492-10-12\"]');
+        res.status(200).type('json').end('[\"2000-12-01\", \"1980-01-02\", \"1492-10-12\"]');
       } else if (req.params.scenario === 'invalidnull') {
         coverage['getArrayDateWithNull']++;
-        res.status(200).end('[\"2012-01-01\", null, \"1776-07-04\"]');
+        res.status(200).type('json').end('[\"2012-01-01\", null, \"1776-07-04\"]');
       } else if (req.params.scenario === 'invalidchars') {
         coverage['getArrayDateWithInvalidChars']++;
-        res.status(200).end('[\"2011-03-22\", \"date\"]');
+        res.status(200).type('json').end('[\"2011-03-22\", \"date\"]');
       } else {
         res.status(400).send('Request scenario for date primitive type must contain valid or invalidnull or invalidchars');
       }
     } else if (req.params.type == 'uuid') {
       if (req.params.scenario === 'valid') {
         coverage['getArrayUuidValid']++;
-        res.status(200).end('[\"6dcc7237-45fe-45c4-8a6b-3a8a3f625652\", \"d1399005-30f7-40d6-8da6-dd7c89ad34db\", \"f42f6aa1-a5bc-4ddf-907e-5f915de43205\"]');
+        res.status(200).type('json').end('[\"6dcc7237-45fe-45c4-8a6b-3a8a3f625652\", \"d1399005-30f7-40d6-8da6-dd7c89ad34db\", \"f42f6aa1-a5bc-4ddf-907e-5f915de43205\"]');
       } else if (req.params.scenario === 'invalidchars') {
         coverage['getArrayUuidWithInvalidChars']++;
-        res.status(200).end('[\"6dcc7237-45fe-45c4-8a6b-3a8a3f625652\", \"foo\"]');
+        res.status(200).type('json').end('[\"6dcc7237-45fe-45c4-8a6b-3a8a3f625652\", \"foo\"]');
       } else {
         res.status(400).send('Request scenario for uuid primitive type must contain valid or invalidchars');
       }
     } else if (req.params.type == 'date-time') {
       if (req.params.scenario === 'valid') {
         coverage['getArrayDateTimeValid']++;
-        res.status(200).end('[\"2000-12-01t00:00:01z\", \"1980-01-02T01:11:35+01:00\", \"1492-10-12T02:15:01-08:00\"]');
+        res.status(200).type('json').end('[\"2000-12-01t00:00:01z\", \"1980-01-02T01:11:35+01:00\", \"1492-10-12T02:15:01-08:00\"]');
       } else if (req.params.scenario === 'invalidnull') {
         coverage['getArrayDateTimeWithNull']++;
-        res.status(200).end('[\"2000-12-01t00:00:01z\", null]');
+        res.status(200).type('json').end('[\"2000-12-01t00:00:01z\", null]');
       } else if (req.params.scenario === 'invalidchars') {
         coverage['getArrayDateTimeWithInvalidChars']++;
-        res.status(200).end('[\"2000-12-01t00:00:01z\", \"date-time\"]');
+        res.status(200).type('json').end('[\"2000-12-01t00:00:01z\", \"date-time\"]');
       } else {
         res.status(400).send('Request scenario for date-time primitive type must contain valid or invalidnull or invalidchars');
       }
     } else if (req.params.type == 'date-time-rfc1123') {
       if (req.params.scenario === 'valid') {
         coverage['getArrayDateTimeRfc1123Valid']++;
-        res.status(200).end('[\"Fri, 01 Dec 2000 00:00:01 GMT\", \"Wed, 02 Jan 1980 00:11:35 GMT\", \"Wed, 12 Oct 1492 10:15:01 GMT\"]');
+        res.status(200).type('json').end('[\"Fri, 01 Dec 2000 00:00:01 GMT\", \"Wed, 02 Jan 1980 00:11:35 GMT\", \"Wed, 12 Oct 1492 10:15:01 GMT\"]');
       } else {
         res.status(400).send('Request scenario for date-time-rfc1123 primitive type must contain valid');
       }
     } else if (req.params.type == 'duration') {
       if (req.params.scenario === 'valid') {
         coverage['getArrayDurationValid']++;
-        res.status(200).end('[\"P123DT22H14M12.011S\", \"P5DT1H0M0S\"]');
+        res.status(200).type('json').end('[\"P123DT22H14M12.011S\", \"P5DT1H0M0S\"]');
       } else {
         res.status(400).send('Request scenario for duration primitive type must contain valid');
       }
@@ -182,19 +182,19 @@ var array = function (coverage) {
         var bytes2 = new Buffer([1, 2, 3]);
         var bytes3 = new Buffer([37, 41, 67]);
         coverage['getArrayByteValid']++;
-        res.status(200).end('[\"' + bytes1.toString('base64') + '\", \"' + bytes2.toString('base64') + '\", \"' +
+        res.status(200).type('json').end('[\"' + bytes1.toString('base64') + '\", \"' + bytes2.toString('base64') + '\", \"' +
                     bytes3.toString('base64') + '\"]');
       } else if (req.params.scenario === 'invalidnull') {
         var bytesNull = new Buffer([171, 172, 173]);
         coverage['getArrayByteWithNull']++;
-        res.status(200).end('[\"' + bytesNull.toString('base64') + '\", null]');
+        res.status(200).type('json').end('[\"' + bytesNull.toString('base64') + '\", null]');
       } else {
         res.status(400).send('Request scenario for byte primitive type must contain valid or invalidnull');
       }
     } else if (req.params.type == 'base64url') {
         if (req.params.scenario === 'valid') {
           coverage['getArrayBase64Url']++;
-          res.status(200).end('[\"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw\", \"dGVzdCBzdHJpbmc\", \"TG9yZW0gaXBzdW0\"]');
+          res.status(200).type('json').end('[\"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw\", \"dGVzdCBzdHJpbmc\", \"TG9yZW0gaXBzdW0\"]');
         } else {
           res.status(400).send('Request scenario for base64url type must contain valid');
         }
@@ -376,16 +376,16 @@ var array = function (coverage) {
       res.status(200).end();
     } else if (req.params.scenario === 'empty') {
       coverage['getArrayComplexEmpty']++;
-      res.status(200).end('[]');
+      res.status(200).type('json').end('[]');
     } else if (req.params.scenario === 'itemnull') {
       coverage['getArrayComplexItemNull']++;
-      res.status(200).end('[{\"integer\": 1, \"string\": \"2\"}, null, {\"integer\": 5, \"string\": \"6\"}]');
+      res.status(200).type('json').end('[{\"integer\": 1, \"string\": \"2\"}, null, {\"integer\": 5, \"string\": \"6\"}]');
     } else if (req.params.scenario === 'itemempty') {
       coverage['getArrayComplexItemEmpty']++;
-      res.status(200).end('[{\"integer\": 1, \"string\": \"2\"}, {}, {\"integer\": 5, \"string\": \"6\"}]');
+      res.status(200).type('json').end('[{\"integer\": 1, \"string\": \"2\"}, {}, {\"integer\": 5, \"string\": \"6\"}]');
     } else if (req.params.scenario === 'valid') {
       coverage['getArrayComplexValid']++;
-      res.status(200).end('[{\"integer\": 1, \"string\": \"2\"}, {\"integer\": 3, \"string\": \"4\"}, {\"integer\": 5, \"string\": \"6\"}]');
+      res.status(200).type('json').end('[{\"integer\": 1, \"string\": \"2\"}, {\"integer\": 3, \"string\": \"4\"}, {\"integer\": 5, \"string\": \"6\"}]');
     } else {
       utils.send400(res, next, 'Request path must contain null, empty, itemnull, itemempty, or valid for complex array get scenarios.')
     }
@@ -419,16 +419,16 @@ var array = function (coverage) {
       res.status(200).end();
     } else if (req.params.scenario === 'empty') {
       coverage['getArrayArrayEmpty']++;
-      res.status(200).end('[]');
+      res.status(200).type('json').end('[]');
     } else if (req.params.scenario === 'itemnull') {
       coverage['getArrayArrayItemNull']++;
-      res.status(200).end('[[\"1\", "2\", \"3\"], null, [\"7\", \"8\", \"9\"]]');
+      res.status(200).type('json').end('[[\"1\", "2\", \"3\"], null, [\"7\", \"8\", \"9\"]]');
     } else if (req.params.scenario === 'itemempty') {
       coverage['getArrayArrayItemEmpty']++;
-      res.status(200).end('[[\"1\", "2\", \"3\"], [], [\"7\", \"8\", \"9\"]]');
+      res.status(200).type('json').end('[[\"1\", "2\", \"3\"], [], [\"7\", \"8\", \"9\"]]');
     } else if (req.params.scenario === 'valid') {
       coverage['getArrayArrayValid']++;
-      res.status(200).end('[[\"1\", "2\", \"3\"], [\"4\", \"5\", \"6\"], [\"7\", \"8\", \"9\"]]');
+      res.status(200).type('json').end('[[\"1\", "2\", \"3\"], [\"4\", \"5\", \"6\"], [\"7\", \"8\", \"9\"]]');
     } else {
       utils.send400(res, next, 'Request path must contain null, empty, itemnull, itemempty, or valid for array of array get scenarios.')
     }
@@ -457,16 +457,16 @@ var array = function (coverage) {
       res.status(200).end();
     } else if (req.params.scenario === 'empty') {
       coverage['getArrayDictionaryEmpty']++;
-      res.status(200).end('[]');
+      res.status(200).type('json').end('[]');
     } else if (req.params.scenario === 'itemnull') {
       coverage['getArrayDictionaryItemNull']++;
-      res.status(200).end('[{\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, null, {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}]');
+      res.status(200).type('json').end('[{\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, null, {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}]');
     } else if (req.params.scenario === 'itemempty') {
       coverage['getArrayDictionaryItemEmpty']++;
-      res.status(200).end('[{\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, {}, {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}]');
+      res.status(200).type('json').end('[{\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, {}, {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}]');
     } else if (req.params.scenario === 'valid') {
       coverage['getArrayDictionaryValid']++;
-      res.status(200).end('[{\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, {\"4\": \"four\", \"5\": \"five\", \"6\": \"six\"}, {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}]');
+      res.status(200).type('json').end('[{\"1\": \"one\", \"2\": \"two\", \"3\": \"three\"}, {\"4\": \"four\", \"5\": \"five\", \"6\": \"six\"}, {\"7\": \"seven\", \"8\": \"eight\", \"9\": \"nine\"}]');
     } else {
       utils.send400(res, next, 'Request path must contain null, empty, itemnull, itemempty, or valid for dictionary array get scenarios.')
     }

--- a/legacy/routes/azureUrl.js
+++ b/legacy/routes/azureUrl.js
@@ -20,7 +20,7 @@ var azureUrl = function (coverage) {
     } else {
       coverage['SubscriptionIdAndApiVersion']++;
       var result = {name: 'testgroup101', location: 'West US'};
-      res.status(200).end(JSON.stringify(result));
+      res.status(200).json(result);
     }
   });
 }

--- a/legacy/routes/bool.js
+++ b/legacy/routes/bool.js
@@ -27,16 +27,16 @@ var bool = function(coverage) {
     router.get('/:scenario', function(req, res, next) {
         if (req.params.scenario === 'true') {
             coverage['getBoolTrue']++;
-            res.status(200).end('true');
+            res.status(200).type('json').end('true');
         } else if (req.params.scenario === 'false') {
             coverage['getBoolFalse']++;
-            res.status(200).end('false');
+            res.status(200).type('json').end('false');
         } else if (req.params.scenario === 'null') {
             coverage['getBoolNull']++;
             res.status(200).end();
         } else if (req.params.scenario === 'invalid') {
             coverage['getBoolInvalid']++;
-            res.status(200).end('true1');
+            res.status(200).type('json').end('true1');
         } else {
             res.status(400).send('Request path must contain true or false');
         }

--- a/legacy/routes/byte.js
+++ b/legacy/routes/byte.js
@@ -26,13 +26,13 @@ var byte = function(coverage) {
             res.status(200).end();
         } else if (req.params.scenario === 'empty') {
             coverage['getByteEmpty']++;
-            res.status(200).end('\"\"');
+            res.status(200).type('json').end('\"\"');
         } else if (req.params.scenario === 'nonAscii') {
             coverage['getByteNonAscii']++;
-            res.status(200).end('\"' + bytes.toString('base64') + '\"');
+            res.status(200).type('json').end('\"' + bytes.toString('base64') + '\"');
         } else if (req.params.scenario === 'invalid') {
             coverage['getByteInvalid']++;
-            res.status(200).end('\"::::SWAGGER::::\"');
+            res.status(200).type('json').end('\"::::SWAGGER::::\"');
         } else {
             res.status(400).send('Request path must contain null or empty or nonAscii or invalid');
         }

--- a/legacy/routes/complex.js
+++ b/legacy/routes/complex.js
@@ -24,19 +24,19 @@ var complex = function (coverage) {
   router.get('/basic/:scenario', function (req, res, next) {
     if (req.params.scenario === 'valid') {
       coverage['getComplexBasicValid']++;
-      res.status(200).end('{ "id": 2, "name": "abc", "color": "YELLOW" }');
+      res.status(200).type('json').end('{ "id": 2, "name": "abc", "color": "YELLOW" }');
     } else if (req.params.scenario === 'empty') {
       coverage['getComplexBasicEmpty']++;
-      res.status(200).end('{ }');
+      res.status(200).type('json').end('{ }');
     } else if (req.params.scenario === 'notprovided') {
       coverage['getComplexBasicNotProvided']++;
       res.status(200).end();
     } else if (req.params.scenario === 'null') {
       coverage['getComplexBasicNull']++;
-      res.status(200).end('{ "id": null, "name": null }');
+      res.status(200).type('json').end('{ "id": null, "name": null }');
     } else if (req.params.scenario === 'invalid') {
       coverage['getComplexBasicInvalid']++;
-      res.status(200).end('{ "id": "a", "name": "abc" }');
+      res.status(200).type('json').end('{ "id": "a", "name": "abc" }');
     } else {
       res.status(400).send('Request scenario must be valid, empty, null, notprovided, or invalid.');
     }
@@ -150,37 +150,37 @@ var complex = function (coverage) {
   router.get('/primitive/:scenario', function (req, res, next) {
     if (req.params.scenario === 'integer') {
       coverage['getComplexPrimitiveInteger']++;
-      res.status(200).end(JSON.stringify(intBody));
+      res.status(200).json(intBody);
     } else if (req.params.scenario === 'long') {
       coverage['getComplexPrimitiveLong']++;
-      res.status(200).end(JSON.stringify(longBody));
+      res.status(200).json(longBody);
     } else if (req.params.scenario === 'float') {
       coverage['getComplexPrimitiveFloat']++;
-      res.status(200).end(JSON.stringify(floatBody));
+      res.status(200).json(floatBody);
     } else if (req.params.scenario === 'double') {
       coverage['getComplexPrimitiveDouble']++;
-      res.status(200).end(JSON.stringify(doubleBody));
+      res.status(200).json(doubleBody);
     } else if (req.params.scenario === 'bool') {
       coverage['getComplexPrimitiveBool']++;
-      res.status(200).end(JSON.stringify(boolBody));
+      res.status(200).json(boolBody);
     } else if (req.params.scenario === 'string') {
       coverage['getComplexPrimitiveString']++;
-      res.status(200).end(JSON.stringify(stringBody));
+      res.status(200).json(stringBody);
     } else if (req.params.scenario === 'date') {
       coverage['getComplexPrimitiveDate']++;
-      res.status(200).end(JSON.stringify(dateBody));
+      res.status(200).json(dateBody);
     } else if (req.params.scenario === 'datetime') {
       coverage['getComplexPrimitiveDateTime']++;
-      res.status(200).end(JSON.stringify(datetimeBody));
+      res.status(200).json(datetimeBody);
     } else if (req.params.scenario === 'datetimerfc1123') {
       coverage['getComplexPrimitiveDateTimeRfc1123']++;
-      res.status(200).end(JSON.stringify(datetimeRfc1123Body));
+      res.status(200).json(datetimeRfc1123Body);
     } else if (req.params.scenario === 'duration') {
       coverage['getComplexPrimitiveDuration']++;
-      res.status(200).end(JSON.stringify(durationBody));
+      res.status(200).json(durationBody);
     } else if (req.params.scenario === 'byte') {
       coverage['getComplexPrimitiveByte']++;
-      res.status(200).end(byteBody);
+      res.status(200).type('json').end(byteBody);
     } else {
       utils.send400(res, next, 'Must provide a valid primitive type scenario.');
     }
@@ -213,13 +213,13 @@ var complex = function (coverage) {
   router.get('/array/:scenario', function (req, res, next) {
     if (req.params.scenario === 'valid') {
       coverage['getComplexArrayValid']++;
-      res.status(200).end(arrayValidBody);
+      res.status(200).type('json').end(arrayValidBody);
     } else if (req.params.scenario === 'empty') {
       coverage['getComplexArrayEmpty']++;
-      res.status(200).end('{"array":[]}');
+      res.status(200).type('json').end('{"array":[]}');
     } else if (req.params.scenario === 'notprovided') {
       coverage['getComplexArrayNotProvided']++;
-      res.status(200).end('{}');
+      res.status(200).type('json').end('{}');
     } else {
       utils.send400(res, next, 'Must provide a valid scenario.');
     }
@@ -252,16 +252,16 @@ var complex = function (coverage) {
   router.get('/dictionary/typed/:scenario', function (req, res, next) {
     if (req.params.scenario === 'valid') {
       coverage['getComplexDictionaryValid']++;
-      res.status(200).end(dictionaryValidBody);
+      res.status(200).type('json').end(dictionaryValidBody);
     } else if (req.params.scenario === 'empty') {
       coverage['getComplexDictionaryEmpty']++;
-      res.status(200).end('{"defaultProgram":{}}');
+      res.status(200).type('json').end('{"defaultProgram":{}}');
     } else if (req.params.scenario === 'null') {
       coverage['getComplexDictionaryNull']++;
-      res.status(200).end('{"defaultProgram":null}');
+      res.status(200).type('json').end('{"defaultProgram":null}');
     } else if (req.params.scenario === 'notprovided') {
       coverage['getComplexDictionaryNotProvided']++;
-      res.status(200).end('{}');
+      res.status(200).type('json').end('{}');
     } else {
       utils.send400(res, next, 'Must provide a valid scenario.');
     }
@@ -299,7 +299,7 @@ var complex = function (coverage) {
   router.get('/inheritance/:scenario', function (req, res, next) {
     if (req.params.scenario === 'valid') {
       coverage['getComplexInheritanceValid']++;
-      res.status(200).end(siamese);
+      res.status(200).type('json').end(siamese);
     } else {
       utils.send400(res, next, 'Must provide a valid scenario.');
     }
@@ -539,19 +539,19 @@ var complex = function (coverage) {
   coverage['getComplexPolymorphismDotSyntax'] = 0;
   router.get('/polymorphism/dotsyntax', function (req, res, next) {
     coverage['getComplexPolymorphismDotSyntax']++;
-    res.status(200).end(JSON.stringify(dotSalmon));
+    res.status(200).json(dotSalmon);
   });
 
   coverage['getComposedWithDiscriminator'] = 0;
   router.get('/polymorphism/composedWithDiscriminator', function (req, res, next) {
     coverage['getComposedWithDiscriminator']++;
-    res.status(200).end(JSON.stringify(dotFishMarketWithDiscriminator));
+    res.status(200).json(dotFishMarketWithDiscriminator);
   });
 
   coverage['getComposedWithoutDiscriminator'] = 0;
   router.get('/polymorphism/composedWithoutDiscriminator', function (req, res, next) {
     coverage['getComposedWithoutDiscriminator']++;
-    res.status(200).end(JSON.stringify(dotFishMarketWithoutDiscriminator));
+    res.status(200).json(dotFishMarketWithoutDiscriminator);
   });
 
   router.put('/polymorphism/:scenario', function (req, res, next) {
@@ -578,7 +578,7 @@ var complex = function (coverage) {
       console.log(JSON.stringify(regularSalmon, null, 4));
       if (_.isEqual(utils.coerceDate(req.body), regularSalmon)) {
         coverage['putComplexPolymorphismNoDiscriminator']++;
-        res.status(200).end(JSON.stringify(regularSalmonWithoutDiscriminator));
+        res.status(200).json(regularSalmonWithoutDiscriminator);
       } else {
         utils.send400(res, next, "Did not like complex polymorphism req " + util.inspect(req.body));
       }
@@ -590,10 +590,10 @@ var complex = function (coverage) {
   router.get('/polymorphism/:scenario', function (req, res, next) {
     if (req.params.scenario === 'valid') {
       coverage['getComplexPolymorphismValid']++;
-      res.status(200).end(JSON.stringify(rawFish));
+      res.status(200).json(rawFish);
     } else if (req.params.scenario === 'complicated') {
       coverage['getComplexPolymorphismComplicated']++;
-      res.status(200).end(JSON.stringify(rawSalmon));
+      res.status(200).json(rawSalmon);
     } else {
       utils.send400(res, next, 'Must provide a valid scenario.');
     }
@@ -685,7 +685,7 @@ var complex = function (coverage) {
   router.get('/polymorphicrecursive/:scenario', function (req, res, next) {
     if (req.params.scenario === 'valid') {
       coverage['getComplexPolymorphicRecursiveValid']++;
-      res.status(200).end(JSON.stringify(bigfishRaw));
+      res.status(200).json(bigfishRaw);
     } else {
       utils.send400(res, next, 'Must provide a valid scenario.');
     }
@@ -693,7 +693,7 @@ var complex = function (coverage) {
 
   router.get('/readonlyproperty/valid', function (req, res, next) {
     coverage['getComplexReadOnlyPropertyValid']++;
-    res.status(200).end(JSON.stringify({ "id": "1234", "size": 2 }));
+    res.status(200).json({ "id": "1234", "size": 2 });
   });
 
   router.put('/readonlyproperty/valid', function (req, res, next) {

--- a/legacy/routes/date.js
+++ b/legacy/routes/date.js
@@ -15,7 +15,7 @@ var date = function(coverage) {
 
     router.get('/max', function(req, res, next) {
         coverage['getDateMax']++;
-        res.status(200).end('"9999-12-31"');
+        res.status(200).type('json').end('"9999-12-31"');
     });
 
     router.put('/min', function(req, res, next) {
@@ -29,7 +29,7 @@ var date = function(coverage) {
 
     router.get('/min', function(req, res, next) {
         coverage['getDateMin']++;
-        res.status(200).end('"0001-01-01"');
+        res.status(200).type('json').end('"0001-01-01"');
     });
 
     router.get('/:scenario', function(req, res, next) {
@@ -38,13 +38,13 @@ var date = function(coverage) {
             res.status(200).end();
         } else if (req.params.scenario === 'invaliddate') {
             coverage['getDateInvalid']++;
-            res.status(200).end('"201O-18-90"');
+            res.status(200).type('json').end('"201O-18-90"');
         } else if (req.params.scenario === 'overflowdate') {
             coverage['getDateOverflow']++;
-            res.status(200).end('"10000000000-12-31"');
+            res.status(200).type('json').end('"10000000000-12-31"');
         } else if (req.params.scenario === 'underflowdate') {
             coverage['getDateUnderflow']++;
-            res.status(200).end('"0000-00-00"');
+            res.status(200).type('json').end('"0000-00-00"');
         } else {
             res.status(400).send('Request path must contain a valid scenario: ' +
                 '"null", "invaliddate", "overflowdate", "underflowdate". Provided value is : ', +

--- a/legacy/routes/datetime-rfc1123.js
+++ b/legacy/routes/datetime-rfc1123.js
@@ -13,7 +13,7 @@ var datetimeRfc1123 = function(coverage) {
       utils.send400(res, next, "Did not like the value provided for max datetime-rfc1123 in the req " + util.inspect(req.body));
     }
   });
-  
+
   router.put('/min', function(req, res, next) {
     if (new Date(req.body).toString() === new Date('Mon, 01 Jan 0001 00:00:00 GMT').toString()) {
       coverage["putDateTimeRfc1123Min"]++;
@@ -22,7 +22,7 @@ var datetimeRfc1123 = function(coverage) {
       utils.send400(res, next, "Did not like the value provided for min datetime-rfc1123 in the req " + util.inspect(req.body));
     }
   });
-  
+
   router.get('/max/:case', function(req, res, next) {
     var ret = '"Fri, 31 Dec 9999 23:59:59 GMT"';
     if (req.params.case === 'lowercase') {
@@ -35,27 +35,27 @@ var datetimeRfc1123 = function(coverage) {
       utils.send400(res, next, 'Please provide a valid case for datetime-rfc1123 case ' +
         '\'uppercase\', \'lowercase\' and not ' + util.inspect(req.params.case));
     }
-    res.status(200).end(ret);
+    res.status(200).type('json').end(ret);
   });
-    
+
   router.get('/min', function(req, res, next) {
     coverage["getDateTimeRfc1123MinUtc"]++;
-    res.status(200).end('"Mon, 01 Jan 0001 00:00:00 GMT"');
+    res.status(200).type('json').end('"Mon, 01 Jan 0001 00:00:00 GMT"');
   });
-  
+
   router.get('/:scenario', function(req, res, next) {
     if (req.params.scenario === 'null') {
       coverage["getDateTimeRfc1123Null"]++;
       res.status(200).end();
     } else if (req.params.scenario === 'invalid') {
       coverage["getDateTimeRfc1123Invalid"]++;
-      res.status(200).end('"Tue, 01 Dec 2000 00:00:0A ABC"');
+      res.status(200).type('json').end('"Tue, 01 Dec 2000 00:00:0A ABC"');
     } else if (req.params.scenario === 'overflow') {
       coverage["getDateTimeRfc1123Overflow"]++;
-      res.status(200).end('"Sat, 1 Jan 10000 00:00:00 GMT"');
+      res.status(200).type('json').end('"Sat, 1 Jan 10000 00:00:00 GMT"');
     } else if (req.params.scenario === 'underflow') {
       coverage["getDateTimeRfc1123Underflow"]++;
-      res.status(200).end('"Tue, 00 Jan 0000 00:00:00 GMT"');
+      res.status(200).type('json').end('"Tue, 00 Jan 0000 00:00:00 GMT"');
     } else {
       res.status(400).send('Request path must contain a valid scenario: ' +
         '"null", "invalid", "overflow", "underflow". Provided value is : ', +

--- a/legacy/routes/datetime.js
+++ b/legacy/routes/datetime.js
@@ -81,7 +81,7 @@ var datetime = function(coverage, optionalCoverage) {
             utils.send400(res, next, 'Please provide a valid case for datetime case ' +
                 '\'uppercase\', \'lowercase\' and not ' + util.inspect(req.params.case));
         }
-        res.status(200).end(ret);
+        res.status(200).type('json').end(ret);
     });
 
     router.put('/min/:type', function(req, res, next) {
@@ -116,13 +116,13 @@ var datetime = function(coverage, optionalCoverage) {
     router.get('/min/:type', function(req, res, next) {
         if (req.params.type === 'utc') {
             coverage["getDateTimeMinUtc"]++;
-            res.status(200).end('"0001-01-01T00:00:00Z"');
+            res.status(200).type('json').end('"0001-01-01T00:00:00Z"');
         } else if (req.params.type === 'localpositiveoffset') {
             coverage["getDateTimeMinLocalPositiveOffset"]++;
-            res.status(200).end('"0001-01-01T00:00:00+14:00"');
+            res.status(200).type('json').end('"0001-01-01T00:00:00+14:00"');
         } else if (req.params.type === 'localnegativeoffset') {
             coverage["getDateTimeMinLocalNegativeOffset"]++;
-            res.status(200).end('"0001-01-01T00:00:00-14:00"');
+            res.status(200).type('json').end('"0001-01-01T00:00:00-14:00"');
         } else {
             utils.send400(res, next, 'Please provide a valid datetime type \'utc\', ' +
                 '\'localpositiveoffset\', \'localnegativeoffset\' and not ' +
@@ -136,13 +136,13 @@ var datetime = function(coverage, optionalCoverage) {
             res.status(200).end();
         } else if (req.params.scenario === 'invalid') {
             coverage["getDateTimeInvalid"]++;
-            res.status(200).end('"201O-18-90D00:89:56.9AX"');
+            res.status(200).type('json').end('"201O-18-90D00:89:56.9AX"');
         } else if (req.params.scenario === 'overflow') {
             coverage["getDateTimeOverflow"]++;
-            res.status(200).end('"9999-12-31T23:59:59.999-14:00"');
+            res.status(200).type('json').end('"9999-12-31T23:59:59.999-14:00"');
         } else if (req.params.scenario === 'underflow') {
             coverage["getDateTimeUnderflow"]++;
-            res.status(200).end('"0000-00-00T00:00:00.000+00:00"');
+            res.status(200).type('json').end('"0000-00-00T00:00:00.000+00:00"');
         } else {
             res.status(400).send('Request path must contain a valid scenario: ' +
                 '"null", "invaliddate", "overflowdate", "underflowdate". Provided value is : ', +

--- a/legacy/routes/dictionary.js
+++ b/legacy/routes/dictionary.js
@@ -24,19 +24,19 @@ var dictionary = function(coverage) {
             res.status(200).end();
         } else if (req.params.scenario === 'empty') {
             coverage['getDictionaryEmpty']++;
-            res.status(200).end('{}');
+            res.status(200).type('json').end('{}');
         } else if (req.params.scenario === 'invalid') {
             coverage['getDictionaryInvalid']++;
-            res.status(200).end('{"key1": "val1", "key2", "val2"');
+            res.status(200).type('json').end('{"key1": "val1", "key2", "val2"');
         } else if (req.params.scenario === 'nullvalue') {
             coverage['getDictionaryNullValue']++;
-            res.status(200).end('{"key1" : null}');
+            res.status(200).type('json').end('{"key1" : null}');
         } else if (req.params.scenario === 'nullkey') {
             coverage['getDictionaryNullkey']++;
-            res.status(200).end('{null : "val1"}');
+            res.status(200).type('json').end('{null : "val1"}');
         } else if (req.params.scenario === 'keyemptystring') {
             coverage['getDictionaryKeyEmptyString']++;
-            res.status(200).end('{"" : "val1"}');
+            res.status(200).type('json').end('{"" : "val1"}');
         } else {
             res.status(400).send('Request path must contain null or empty or invalid');
         }
@@ -46,143 +46,143 @@ var dictionary = function(coverage) {
         if (req.params.type == 'boolean') {
             if (req.params.scenario === 'tfft') {
                 coverage['getDictionaryBooleanValid']++;
-                res.status(200).end('{"0": true, "1": false, "2": false, "3": true }');
+                res.status(200).type('json').end('{"0": true, "1": false, "2": false, "3": true }');
             } else if (req.params.scenario === 'true.null.false') {
                 coverage['getDictionaryBooleanWithNull']++;
-                res.status(200).end('{"0": true, "1": null, "2": false }');
+                res.status(200).type('json').end('{"0": true, "1": null, "2": false }');
             } else if (req.params.scenario === 'true.boolean.false') {
                 coverage['getDictionaryBooleanWithString']++;
-                res.status(200).end('{"0": true, "1": "boolean", "2": false}');
+                res.status(200).type('json').end('{"0": true, "1": "boolean", "2": false}');
             } else {
                 res.status(400).send('Request scenario for boolean primitive type must contain tfft or true.null.false or true.boolean.false');
             }
         } else if (req.params.type == 'integer') {
             if (req.params.scenario === '1.-1.3.300') {
                 coverage['getDictionaryIntegerValid']++;
-                res.status(200).end('{"0": 1, "1": -1, "2": 3, "3": 300}');
+                res.status(200).type('json').end('{"0": 1, "1": -1, "2": 3, "3": 300}');
             } else if (req.params.scenario === '1.null.zero') {
                 coverage['getDictionaryIntegerWithNull']++;
-                res.status(200).end('{"0": 1, "1": null, "2": 0}');
+                res.status(200).type('json').end('{"0": 1, "1": null, "2": 0}');
             } else if (req.params.scenario === '1.integer.0') {
                 coverage['getDictionaryIntegerWithString']++;
-                res.status(200).end('{"0": 1, "1": "integer", "2": 0}');
+                res.status(200).type('json').end('{"0": 1, "1": "integer", "2": 0}');
             } else {
                 res.status(400).send('Request scenario for integer primitive type must contain 1.-1.3.300 or 1.null.zero or 1.boolean.0');
             }
         } else if (req.params.type == 'long') {
             if (req.params.scenario === '1.-1.3.300') {
                 coverage['getDictionaryLongValid']++;
-                res.status(200).end('{"0": 1, "1": -1, "2": 3, "3": 300}');
+                res.status(200).type('json').end('{"0": 1, "1": -1, "2": 3, "3": 300}');
             } else if (req.params.scenario === '1.null.zero') {
                 coverage['getDictionaryLongWithNull']++;
-                res.status(200).end('{"0": 1, "1": null, "2": 0}');
+                res.status(200).type('json').end('{"0": 1, "1": null, "2": 0}');
             } else if (req.params.scenario === '1.integer.0') {
                 coverage['getDictionaryLongWithString']++;
-                res.status(200).end('{"0": 1, "1": "integer", "2": 0}');
+                res.status(200).type('json').end('{"0": 1, "1": "integer", "2": 0}');
             } else {
                 res.status(400).send('Request scenario for long primitive type must contain 1.-1.3.300 or 1.null.zero or 1.boolean.0');
             }
         } else if (req.params.type == 'float') {
             if (req.params.scenario === '0--0.01-1.2e20') {
                 coverage['getDictionaryFloatValid']++;
-                res.status(200).end('{"0": 0, "1": -0.01, "2": -1.2e20}');
+                res.status(200).type('json').end('{"0": 0, "1": -0.01, "2": -1.2e20}');
             } else if (req.params.scenario === '0.0-null-1.2e20') {
                 coverage['getDictionaryFloatWithNull']++;
-                res.status(200).end('{"0": 0.0, "1": null, "2": -1.2e20}');
+                res.status(200).type('json').end('{"0": 0.0, "1": null, "2": -1.2e20}');
             } else if (req.params.scenario === '1.number.0') {
                 coverage['getDictionaryFloatWithString']++;
-                res.status(200).end('{"0": 1, "1": "number", "2": 0}');
+                res.status(200).type('json').end('{"0": 1, "1": "number", "2": 0}');
             } else {
                 res.status(400).send('Request scenario for float primitive type must contain 0--0.01-1.2e20 or 0.0-null-1.2e20 or 1.number.0');
             }
         } else if (req.params.type == 'double') {
             if (req.params.scenario === '0--0.01-1.2e20') {
                 coverage['getDictionaryDoubleValid']++;
-                res.status(200).end('{"0": 0, "1": -0.01, "2": -1.2e20}');
+                res.status(200).type('json').end('{"0": 0, "1": -0.01, "2": -1.2e20}');
             } else if (req.params.scenario === '0.0-null-1.2e20') {
                 coverage['getDictionaryDoubleWithNull']++;
-                res.status(200).end('{"0": 0.0, "1": null, "2": -1.2e20}');
+                res.status(200).type('json').end('{"0": 0.0, "1": null, "2": -1.2e20}');
             } else if (req.params.scenario === '1.number.0') {
                 coverage['getDictionaryDoubleWithString']++;
-                res.status(200).end('{"0": 1, "1": "number", "2": 0}');
+                res.status(200).type('json').end('{"0": 1, "1": "number", "2": 0}');
             } else {
                 res.status(400).send('Request scenario for double primitive type must contain 0--0.01-1.2e20 or 0.0-null-1.2e20 or 1.number.0');
             }
         } else if (req.params.type == 'string') {
             if (req.params.scenario === 'foo1.foo2.foo3') {
                 coverage['getDictionaryStringValid']++;
-                res.status(200).end('{"0": "foo1", "1": "foo2", "2": "foo3"}');
+                res.status(200).type('json').end('{"0": "foo1", "1": "foo2", "2": "foo3"}');
             } else if (req.params.scenario === 'foo.null.foo2') {
                 coverage['getDictionaryStringWithNull']++;
-                res.status(200).end('{"0": "foo", "1": null, "2": "foo2" }');
+                res.status(200).type('json').end('{"0": "foo", "1": null, "2": "foo2" }');
             } else if (req.params.scenario === 'foo.123.foo2') {
                 coverage['getDictionaryStringWithNumber']++;
-                res.status(200).end('{"0": "foo", "1": 123, "2": "foo2"}');
+                res.status(200).type('json').end('{"0": "foo", "1": 123, "2": "foo2"}');
             } else {
                 res.status(400).send('Request scenario for float primitive type must contain foo1.foo2.foo3 or foo.null.foo2 or foo.123.foo2');
             }
         } else if (req.params.type == 'date') {
             if (req.params.scenario === 'valid') {
                 coverage['getDictionaryDateValid']++;
-                res.status(200).end('{"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}');
+                res.status(200).type('json').end('{"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}');
             } else if (req.params.scenario === 'invalidnull') {
                 coverage['getDictionaryDateWithNull']++;
-                res.status(200).end('{"0": "2012-01-01", "1": null, "2": "1776-07-04"}');
+                res.status(200).type('json').end('{"0": "2012-01-01", "1": null, "2": "1776-07-04"}');
             } else if (req.params.scenario === 'invalidchars') {
                 coverage['getDictionaryDateWithInvalidChars']++;
-                res.status(200).end('{"0": "2011-03-22", "1": "date"}');
+                res.status(200).type('json').end('{"0": "2011-03-22", "1": "date"}');
             } else {
                 res.status(400).send('Request scenario for date primitive type must contain valid or invalidnull or invalidchars');
             }
         } else if (req.params.type == 'date-time') {
             if (req.params.scenario === 'valid') {
                 coverage['getDictionaryDateTimeValid']++;
-                res.status(200).end('{"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}');
+                res.status(200).type('json').end('{"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2": "1492-10-12T10:15:01-08:00"}');
             } else if (req.params.scenario === 'invalidnull') {
                 coverage['getDictionaryDateTimeWithNull']++;
-                res.status(200).end('{"0": "2000-12-01t00:00:01z", "1": null}');
+                res.status(200).type('json').end('{"0": "2000-12-01t00:00:01z", "1": null}');
             } else if (req.params.scenario === 'invalidchars') {
                 coverage['getDictionaryDateTimeWithInvalidChars']++;
-                res.status(200).end('{"0": "2000-12-01t00:00:01z", "1": "date-time"}');
+                res.status(200).type('json').end('{"0": "2000-12-01t00:00:01z", "1": "date-time"}');
             } else {
                 res.status(400).send('Request scenario for date-time primitive type must contain valid or invalidnull or invalidchars');
             }
         } else if (req.params.type == 'date-time-rfc1123') {
             if (req.params.scenario === 'valid') {
                 coverage['getDictionaryDateTimeRfc1123Valid']++;
-                res.status(200).end('{"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}');
+                res.status(200).type('json').end('{"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}');
             } else {
                 res.status(400).send('Request scenario for date-time-rfc1123 primitive type must contain valid');
             }
         } else if (req.params.type == 'duration') {
             if (req.params.scenario === 'valid') {
                 coverage['getDictionaryDurationValid']++;
-                res.status(200).end('{"0": "P123DT22H14M12.011S", "1": "P5DT1H"}');
+                res.status(200).type('json').end('{"0": "P123DT22H14M12.011S", "1": "P5DT1H"}');
             } else {
                 res.status(400).send('Request scenario for duration primitive type must contain valid');
-            }            
+            }
         } else if (req.params.type == 'byte') {
             if (req.params.scenario === 'valid') {
                 var bytes1 = new Buffer([255, 255, 255, 250]);
                 var bytes2 = new Buffer([1, 2, 3]);
                 var bytes3 = new Buffer([37, 41 , 67]);
                 coverage['getDictionaryByteValid']++;
-                res.status(200).end('{"0": "' + bytes1.toString('base64') + '", "1": "' + bytes2.toString('base64') + '", "2": "' +
+                res.status(200).type('json').end('{"0": "' + bytes1.toString('base64') + '", "1": "' + bytes2.toString('base64') + '", "2": "' +
                     bytes3.toString('base64') + '"}');
             } else if (req.params.scenario === 'invalidnull') {
                 var bytesNull = new Buffer([171, 172, 173]);
                 coverage['getDictionaryByteWithNull']++;
-                res.status(200).end('{"0": "' + bytesNull.toString('base64') + '", "1": null}');
+                res.status(200).type('json').end('{"0": "' + bytesNull.toString('base64') + '", "1": null}');
             } else {
                 res.status(400).send('Request scenario for byte primitive type must contain valid or invalidnull');
             }
         } else if (req.params.type == 'base64url') {
             if (req.params.scenario === 'valid') {
                 coverage['getDictionaryBase64Url']++;
-                res.status(200).end('{"0": "YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw", "1": "dGVzdCBzdHJpbmc", "2": "TG9yZW0gaXBzdW0"}');
+                res.status(200).type('json').end('{"0": "YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw", "1": "dGVzdCBzdHJpbmc", "2": "TG9yZW0gaXBzdW0"}');
             } else {
                 res.status(400).send('Request scenario for base64url type must contain valid');
-            }            
+            }
         } else {
             res.status(400).send('Request path must contain boolean or integer or float or double or string or date or date-time or byte or base64url');
         }
@@ -325,16 +325,16 @@ var dictionary = function(coverage) {
             res.status(200).end();
         } else if (req.params.scenario === 'empty') {
             coverage['getDictionaryComplexEmpty']++;
-            res.status(200).end('{}');
+            res.status(200).type('json').end('{}');
         } else if (req.params.scenario === 'itemnull') {
             coverage['getDictionaryComplexItemNull']++;
-            res.status(200).end('{"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}');
+            res.status(200).type('json').end('{"0": {"integer": 1, "string": "2"}, "1": null, "2": {"integer": 5, "string": "6"}}');
         } else if (req.params.scenario === 'itemempty') {
             coverage['getDictionaryComplexItemEmpty']++;
-            res.status(200).end('{"0": {"integer": 1, "string": "2"}, "1": {}, "2": {"integer": 5, "string": "6"}}');
+            res.status(200).type('json').end('{"0": {"integer": 1, "string": "2"}, "1": {}, "2": {"integer": 5, "string": "6"}}');
         } else if (req.params.scenario === 'valid') {
             coverage['getDictionaryComplexValid']++;
-            res.status(200).end('{"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}');
+            res.status(200).type('json').end('{"0": {"integer": 1, "string": "2"}, "1": {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}');
         } else {
 		utils.send400(res, next, 'Request path must contain null, empty, itemnull, itemempty, or valid for complex dictionary get scenarios.');
         }
@@ -359,16 +359,16 @@ var dictionary = function(coverage) {
             res.status(200).end();
         } else if (req.params.scenario === 'empty') {
             coverage['getDictionaryArrayEmpty']++;
-            res.status(200).end('{}');
+            res.status(200).type('json').end('{}');
         } else if (req.params.scenario === 'itemnull') {
             coverage['getDictionaryArrayItemNull']++;
-            res.status(200).end('{"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}');
+            res.status(200).type('json').end('{"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}');
         } else if (req.params.scenario === 'itemempty') {
             coverage['getDictionaryArrayItemEmpty']++;
-            res.status(200).end('{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}');
+            res.status(200).type('json').end('{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}');
         } else if (req.params.scenario === 'valid') {
             coverage['getDictionaryArrayValid']++;
-            res.status(200).end('{"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}');
+            res.status(200).type('json').end('{"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8", "9"]}');
         } else {
 		utils.send400(res, next, 'Request path must contain null, empty, itemnull, itemempty, or valid for dictionary of array get scenarios.')
         }
@@ -393,16 +393,16 @@ var dictionary = function(coverage) {
             res.status(200).end();
         } else if (req.params.scenario === 'empty') {
             coverage['getDictionaryDictionaryEmpty']++;
-            res.status(200).end('{}');
+            res.status(200).type('json').end('{}');
         } else if (req.params.scenario === 'itemnull') {
             coverage['getDictionaryDictionaryItemNull']++;
-            res.status(200).end('{"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}');
+            res.status(200).type('json').end('{"0": {"1": "one", "2": "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}');
         } else if (req.params.scenario === 'itemempty') {
             coverage['getDictionaryDictionaryItemEmpty']++;
-            res.status(200).end('{"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}');
+            res.status(200).type('json').end('{"0": {"1": "one", "2": "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}');
         } else if (req.params.scenario === 'valid') {
             coverage['getDictionaryDictionaryValid']++;
-            res.status(200).end('{"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}');
+            res.status(200).type('json').end('{"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}');
         } else {
 		utils.send400(res, next, 'Request path must contain null, empty, itemnull, itemempty, or valid for dictionary dictionary get scenarios.');
         }

--- a/legacy/routes/duration.js
+++ b/legacy/routes/duration.js
@@ -15,7 +15,7 @@ var duration = function(coverage, optionalCoverage) {
             // res.status(200).end();
         // } else {
             // utils.send400(res, next, "Did not like the value provided for negative duration " + util.inspect(req.body));
-        // }        
+        // }
     // });
 
     router.put('/positiveduration', function(req, res, next) {
@@ -28,21 +28,21 @@ var duration = function(coverage, optionalCoverage) {
             utils.send400(res, next, "Did not like the value provided for positive duration " + util.inspect(req.body));
         }
     });
-    
+
     router.get('/:scenario', function(req, res, next) {
         if (req.params.scenario === 'null') {
             coverage["getDurationNull"]++;
             res.status(200).end();
         } else if (req.params.scenario === 'invalid') {
             coverage["getDurationInvalid"]++;
-            res.status(200).end('"123ABC"');
+            res.status(200).type('json').end('"123ABC"');
         } else if (req.params.scenario === 'positiveduration') {
             coverage["getDurationPositive"]++;
-            res.status(200).end('"P3Y6M4DT12H30M5S"');
+            res.status(200).type('json').end('"P3Y6M4DT12H30M5S"');
         //TODO: It looks like ISO8601 doesn't cover negative durations (so there is no standard)... omitting for now
         // } else if (req.params.scenario === 'negativeduration') {
             // coverage["getDurationNegative"]++;
-            // res.status(200).end('"-P3Y6M4DT12H30M5S"');
+            // res.status(200).type('json').end('"-P3Y6M4DT12H30M5S"');
         } else {
             res.status(400).send('Request path must contain a valid scenario: ' +
                 '"null", "invalid", "positiveduration", "negativeduration". Provided value is : ', +

--- a/legacy/routes/errorStatusCodes.js
+++ b/legacy/routes/errorStatusCodes.js
@@ -50,14 +50,14 @@ var pathitem = function(coverage) {
         console.log('Inside action: "' + whatAction +'"\n');
         if (whatAction === 'stay') {
             coverage['expectedNoErrors']++;
-            res.status(200).end(JSON.stringify(tommyPet));
+            res.status(200).json(tommyPet);
         }
         else if(whatAction === 'jump'){
-            res.status(500).end(JSON.stringify(sadCasper));
+            res.status(500).json(sadCasper);
             coverage['expectedPetSadError']++;
         }
         else if(whatAction === 'fetch'){
-            res.status(404).end(JSON.stringify(hungryScooby));
+            res.status(404).json(hungryScooby);
             coverage['expectedPetHungryError']++;
         }
         else{
@@ -70,26 +70,26 @@ var pathitem = function(coverage) {
         console.log('Inside petfinder for '+petId+'\n');
         if (petId === 'tommy') {
             coverage['expectedNoErrors']++;
-            res.status(200).end(JSON.stringify(tommyPet));
+            res.status(200).json(tommyPet);
         }
         else if(petId === 'django') {
             res.status(202).end();
         }
         else if(petId === 'coyoteUgly'){
             coverage['animalNotFoundError']++;
-            res.status(404).end(JSON.stringify(animalNotFoundError));
+            res.status(404).json(animalNotFoundError);
         }
         else if(petId === 'weirdAlYankovic'){
             coverage['linkNotFoundError']++;
-            res.status(404).end(JSON.stringify(linkNotFoundError));
+            res.status(404).json(linkNotFoundError);
         }
         else if(petId === 'ringo'){
             coverage['stringError']++;
-            res.status(400).end(JSON.stringify(petId+stringError));
+            res.status(400).json(petId+stringError);
         }
         else if(petId === 'alien123'){
             coverage['intError']++;
-            res.status(501).end(JSON.stringify(intError));
+            res.status(501).json(intError);
         }
         else {
             res.status(402).end("That's all folks!!");

--- a/legacy/routes/extensibleEnums.js
+++ b/legacy/routes/extensibleEnums.js
@@ -29,14 +29,14 @@ var pathitem = function(coverage) {
         console.log('Inside pathItem handler with petId "' + petId +'"\n');
         if (petId === 'tommy') {
             coverage['expectedEnum']++;
-            res.status(200).end(JSON.stringify(tommy));
-        } 
+            res.status(200).json(tommy);
+        }
         else if(petId === 'casper'){
-            res.status(200).end(JSON.stringify(casper));
+            res.status(200).json(casper);
             coverage['unexpectedEnum']++;
         }
         else if(petId === 'scooby'){
-            res.status(200).end(JSON.stringify(scooby));
+            res.status(200).json(scooby);
             coverage['allowedValueEnum']++;
         }
         else{
@@ -49,7 +49,7 @@ var pathitem = function(coverage) {
         console.log('Inside addPet for '+petName+'\n');
         if (petName === 'Retriever') {
             coverage['roundTripEnum']++;
-            res.status(200).end(JSON.stringify(req.body));
+            res.status(200).json(req.body);
         }
         else{
             utils.send400(res, next, 'Pet info incorrect '+petName);

--- a/legacy/routes/httpResponses.js
+++ b/legacy/routes/httpResponses.js
@@ -552,7 +552,7 @@ var httpResponses = function(coverage, optionalCoverage) {
             coverage[scenario]++;
             if (req.params.type === 'valid') {
                 if (code === 200 ) {
-                    res.status(200).end('{ "statusCode": "200" }');
+                    res.status(200).type('json').end('{ "statusCode": "200" }');
                 } else if (code === 201) {
                     res.status(201).end('{ "statusCode": "201" , "textStatusCode": "Created" }');
                 } else {
@@ -576,7 +576,7 @@ var httpResponses = function(coverage, optionalCoverage) {
             coverage[scenario]++;
             if (req.params.type === 'valid') {
                 if (code === 200 ) {
-                    res.status(200).end('{ "statusCode": "200" }');
+                    res.status(200).type('json').end('{ "statusCode": "200" }');
                 } else if (code === 201) {
                     res.status(201).end('{ "httpCode": "201" }');
                 } else if (code === 404) {

--- a/legacy/routes/int.js
+++ b/legacy/routes/int.js
@@ -52,25 +52,25 @@ var integer = function(coverage) {
             res.status(200).end();
         } else if (req.params.scenario === 'invalid') {
             coverage['getIntegerInvalid']++;
-            res.status(200).end('123jkl');
+            res.status(200).type('json').end('123jkl');
         } else if (req.params.scenario === 'overflowint32') {
             coverage['getIntegerOverflow']++;
-            res.status(200).end('2147483656');
+            res.status(200).type('json').end('2147483656');
         } else if (req.params.scenario === 'underflowint32') {
             coverage['getIntegerUnderflow']++;
-            res.status(200).end('-2147483656');
+            res.status(200).type('json').end('-2147483656');
         } else if (req.params.scenario === 'overflowint64') {
             coverage['getLongOverflow']++;
-            res.status(200).end('9223372036854775910');
+            res.status(200).type('json').end('9223372036854775910');
         } else if (req.params.scenario === 'underflowint64') {
             coverage['getLongUnderflow']++;
-            res.status(200).end('-9223372036854775910');
+            res.status(200).type('json').end('-9223372036854775910');
         } else if (req.params.scenario === 'unixtime') {
             coverage['getUnixTime']++;
-            res.status(200).end('1460505600');
+            res.status(200).type('json').end('1460505600');
         } else if (req.params.scenario === 'invalidunixtime') {
             coverage['getInvalidUnixTime']++;
-            res.status(200).end('123jkl');
+            res.status(200).type('json').end('123jkl');
         } else if (req.params.scenario === 'nullunixtime') {
             coverage['getNullUnixTime']++;
             res.status(200).end();
@@ -78,7 +78,7 @@ var integer = function(coverage) {
             res.status(400).send('Request path must contain true or false');
         }
     });
-    
+
     router.put('/unixtime', function(req, res, next) {
           if (req.body != 1460505600) {
               utils.send400(res, next, "Did not like the value provided for unixtime in the req " + util.inspect(req.body));

--- a/legacy/routes/lros.js
+++ b/legacy/routes/lros.js
@@ -47,13 +47,13 @@ var lros = function (coverage) {
   coverage['CustomHeaderPostSucceeded'] = 0;
   router.put('/put/200/succeeded', function (req, res, next) {
     coverage['LROPutInlineComplete']++;
-    res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+    res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
   });
 
   coverage['LROPut200InlineCompleteNoState'] = 0;
   router.put('/put/200/succeeded/nostate', function (req, res, next) {
     coverage['LROPut200InlineCompleteNoState']++;
-    res.status(200).end('{"id": "100", "name": "foo" }');
+    res.status(200).type('json').end('{"id": "100", "name": "foo" }');
   });
 
   coverage['LROPut202Retry200'] = 0;
@@ -68,7 +68,7 @@ var lros = function (coverage) {
 
   router.get('/put/202/retry/operationResults/200', function (req, res, next) {
     coverage['LROPut202Retry200']++;
-    res.status(200).end('{"id": "100", "name": "foo" }');
+    res.status(200).type('json').end('{"id": "100", "name": "foo" }');
   });
 
   coverage['LROPutSucceededWithBody'] = 0; // /put/201/creating/succeeded/200
@@ -166,7 +166,7 @@ var lros = function (coverage) {
 
     var scenario = getLROAsyncScenarioName("putasync", retry, finalState);
     if (scenario) {
-      res.status(200).end('{ "properties": { "provisioningState": "' + finalState + '"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "' + finalState + '"}, "id": "100", "name": "foo" }');
     } else {
       utils.send400(res, next, 'Unable to parse "putAsync" scenario with retry: "' + retry + '", finalState: "' + finalState + '"');
     }
@@ -222,7 +222,7 @@ var lros = function (coverage) {
     } else {
       removeScenarioCookie(res);
       coverage[scenario]++;
-      res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
     }
   });
 
@@ -238,7 +238,7 @@ var lros = function (coverage) {
 
   router.get('/putasync/noheader/201/200', function (req, res, next) {
     coverage['LROPutAsyncNoHeaderInRetry']++;
-    res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+    res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
   });
 
   router.get('/putasync/noheader/operationresults/123', function (req, res, next) {
@@ -246,10 +246,10 @@ var lros = function (coverage) {
     console.log('In scenario: ' + scenario + '\n');
     if (!hasScenarioCookie(req, scenario)) {
       addScenarioCookie(res, scenario);
-      res.status(200).end('{ "status": "InProgress"}');
+      res.status(200).type('json').end('{ "status": "InProgress"}');
     } else {
       removeScenarioCookie(res);
-      res.status(200).end('{ "status": "Succeeded"}');
+      res.status(200).type('json').end('{ "status": "Succeeded"}');
     }
   });
 
@@ -290,11 +290,11 @@ var lros = function (coverage) {
     console.log('In scenario: ' + scenario + '\n');
     if (!hasScenarioCookie(req, scenario)) {
       addScenarioCookie(res, scenario);
-      res.status(200).end('{ "status": "InProgress"}');
+      res.status(200).type('json').end('{ "status": "InProgress"}');
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "status": "Succeeded"}');
+      res.status(200).type('json').end('{ "status": "Succeeded"}');
     }
   });
 
@@ -316,7 +316,7 @@ var lros = function (coverage) {
     } else {
       removeScenarioCookie(res);
       coverage[scenario]++;
-      res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "subresource": "sub1" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "subresource": "sub1" }');
     }
   });
 
@@ -331,7 +331,7 @@ var lros = function (coverage) {
   });
 
   router.get('/putsubresourceasync/202/200', function (req, res, next) {
-    res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "subresource": "sub1" }');
+    res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "subresource": "sub1" }');
   });
 
   router.get('/putsubresourceasync/operationresults/123', function (req, res, next) {
@@ -340,10 +340,10 @@ var lros = function (coverage) {
     console.log('In scenario: ' + scenario + '\n');
     if (!hasScenarioCookie(req, scenario)) {
       addScenarioCookie(res, scenario);
-      res.status(200).end('{ "status": "InProgress"}');
+      res.status(200).type('json').end('{ "status": "InProgress"}');
     } else {
       removeScenarioCookie(res);
-      res.status(200).end('{ "status": "Succeeded"}');
+      res.status(200).type('json').end('{ "status": "Succeeded"}');
     }
   });
 
@@ -365,7 +365,7 @@ var lros = function (coverage) {
     } else {
       removeScenarioCookie(res);
       coverage[scenario]++;
-      res.status(200).end('{ "name": "sku" , "id": "100" }');
+      res.status(200).type('json').end('{ "name": "sku" , "id": "100" }');
     }
   });
 
@@ -380,7 +380,7 @@ var lros = function (coverage) {
   });
 
   router.get('/putnonresourceasync/202/200', function (req, res, next) {
-    res.status(200).end('{ "name": "sku" , "id": "100" }');
+    res.status(200).type('json').end('{ "name": "sku" , "id": "100" }');
   });
 
   router.get('/putnonresourceasync/operationresults/123', function (req, res, next) {
@@ -388,11 +388,11 @@ var lros = function (coverage) {
     console.log('In scenario: ' + scenario + '\n');
     if (!hasScenarioCookie(req, scenario)) {
       addScenarioCookie(res, scenario);
-      res.status(200).end('{ "status": "InProgress"}');
+      res.status(200).type('json').end('{ "status": "InProgress"}');
     } else {
       removeScenarioCookie(res);
       coverage[scenario]++;
-      res.status(200).end('{ "status": "Succeeded"}');
+      res.status(200).type('json').end('{ "status": "Succeeded"}');
     }
   });
 
@@ -610,7 +610,7 @@ var lros = function (coverage) {
     if (scenario) {
       coverage[scenario]++;
       if (finalCode === 200) {
-        res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+        res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
       } else {
         res.status(finalCode).end();
       }
@@ -633,7 +633,7 @@ var lros = function (coverage) {
   router.get('/post/payload/200', function (req, res, next) {
     var scenario = 'LROPost200';
     coverage[scenario]++;
-    res.status(200).end('{"id":"1", "name":"product"}');
+    res.status(200).type('json').end('{"id":"1", "name":"product"}');
   });
 
   // Initial call is 202 with no body and Location and Azure-AsyncOperation
@@ -650,10 +650,10 @@ var lros = function (coverage) {
     res.set(headers).status(202).end('');
   });
   router.get('/LROPostDoubleHeadersFinalLocationGet/asyncOperationUrl', function (req, res, next) {
-    res.status(200).end('{ "status": "succeeded"} ');
+    res.status(200).type('json').end('{ "status": "succeeded"} ');
   });
   router.get('/LROPostDoubleHeadersFinalLocationGet/location', function (req, res, next) {
-    res.status(200).end('{ "id": "100", "name": "foo" }');
+    res.status(200).type('json').end('{ "id": "100", "name": "foo" }');
     coverage['LROPostDoubleHeadersFinalLocationGet']++;
   });
 
@@ -670,7 +670,7 @@ var lros = function (coverage) {
     res.set(headers).status(202).end('');
   });
   router.get('/LROPostDoubleHeadersFinalAzureHeaderGet/asyncOperationUrl', function (req, res, next) {
-    res.status(200).end('{ "status": "succeeded", "id": "100"} ');
+    res.status(200).type('json').end('{ "status": "succeeded", "id": "100"} ');
     coverage['LROPostDoubleHeadersFinalAzureHeaderGet']++;
   });
   router.get('/LROPostDoubleHeadersFinalAzureHeaderGet/location', function (req, res, next) {
@@ -690,7 +690,7 @@ var lros = function (coverage) {
     res.set(headers).status(202).end('');
   });
   router.get('/LROPostDoubleHeadersFinalAzureHeaderGetDefault/asyncOperationUrl', function (req, res, next) {
-    res.status(200).end('{ "status": "succeeded", "id": "100"} ');
+    res.status(200).type('json').end('{ "status": "succeeded", "id": "100"} ');
     coverage['LROPostDoubleHeadersFinalAzureHeaderGetDefault']++;
   });
   router.get('/LROPostDoubleHeadersFinalAzureHeaderGetDefault/location', function (req, res, next) {
@@ -770,11 +770,11 @@ var lros = function (coverage) {
     var scenario = getLROAsyncScenarioName(operation, retry, finalState);
     console.log('In scenario: ' + scenario + '\n');
 
-    //res.status(200).end('{ "id": "100", "name": "foo" }');
+    //res.status(200).type('json').end('{ "id": "100", "name": "foo" }');
 
     if (!hasScenarioCookie(req, scenario)) {
       addScenarioCookie(res, scenario);
-      res.status(200).end('{ "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "id": "100", "name": "foo" }');
     } else {
       removeScenarioCookie(res);
       coverage[scenario]++;
@@ -790,7 +790,7 @@ var lros = function (coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
     }
   });
 
@@ -821,7 +821,7 @@ var lros = function (coverage) {
       } else {
         coverage[scenario]++;
         removeScenarioCookie(res);
-        res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+        res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
       }
     } else {
       utils.send400(res, next, 'Unable to parse "put" scenario with initialCode: "201" initialState: "Creating", finalState: "Succeeded", finalCode: "200"');
@@ -844,7 +844,7 @@ var lros = function (coverage) {
       res.set(headers).status(500).end();
     } else {
       removeScenarioCookie(res);
-      res.status(200).set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
     }
   });
 
@@ -856,7 +856,7 @@ var lros = function (coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
     }
   });
 
@@ -868,7 +868,7 @@ var lros = function (coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "status": "Succeeded" }');
+      res.status(200).type('json').end('{ "status": "Succeeded" }');
     }
   });
 
@@ -897,7 +897,7 @@ var lros = function (coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
     }
   });
 
@@ -926,7 +926,7 @@ var lros = function (coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
     }
   });
 
@@ -956,7 +956,7 @@ var lros = function (coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "status": "Succeeded" }');
+      res.status(200).type('json').end('{ "status": "Succeeded" }');
     }
   });
 
@@ -998,7 +998,7 @@ var lros = function (coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
     }
   });
 
@@ -1029,7 +1029,7 @@ var lros = function (coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "status": "Succeeded" }');
+      res.status(200).type('json').end('{ "status": "Succeeded" }');
     }
   });
 
@@ -1041,7 +1041,7 @@ var lros = function (coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "name": "sku" , "id": "100" }');
+      res.status(200).type('json').end('{ "name": "sku" , "id": "100" }');
     }
   });
 
@@ -1081,7 +1081,7 @@ var lros = function (coverage) {
       'Location': pollingUri,
       'Retry-After': 0
     };
-    res.status(200).set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
+    res.status(200).type('json').set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
   });
 
   router.get('/nonretryerror/putasync/retry/failed/operationResults/400', function (req, res, next) {
@@ -1182,16 +1182,16 @@ var lros = function (coverage) {
       'Location': pollingUri,
       'Retry-After': 0
     };
-    res.status(200).set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
+    res.status(200).type('json').set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
   });
 
   router.get('/error/putasync/retry/nostatus', function (req, res, next) {
-    res.status(200).end('{ }');
+    res.status(200).type('json').end('{ }');
   });
 
   router.get('/error/putasync/retry/failed/operationResults/nostatus', function (req, res, next) {
     coverage['LROErrorPutAsyncNoPollingStatus']++;
-    res.status(200).end('{ }');
+    res.status(200).type('json').end('{ }');
   });
 
   coverage['LROErrorPutAsyncNoPollingStatusPayload'] = 0;
@@ -1202,7 +1202,7 @@ var lros = function (coverage) {
       'Location': pollingUri,
       'Retry-After': 0
     };
-    res.status(200).set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
+    res.status(200).type('json').set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
   });
 
   router.get('/error/putasync/retry/nostatuspayload', function (req, res, next) {
@@ -1217,11 +1217,11 @@ var lros = function (coverage) {
   coverage['LROErrorPut200InvalidJson'] = 0;
   router.put('/error/put/200/invalidjson', function (req, res, next) {
     coverage['LROErrorPut200InvalidJson']++;
-    res.status(200).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo"');
+    res.status(200).type('json').end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo"');
   });
 
   router.get('/error/put/200/invalidjson', function (req, res, next) {
-    res.status(200).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo"');
+    res.status(200).type('json').end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo"');
   });
 
   coverage['LROErrorPutAsyncInvalidHeader'] = 0;
@@ -1233,7 +1233,7 @@ var lros = function (coverage) {
       'Location': pollingUri,
       'Retry-After': '/bar'
     };
-    res.status(200).set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
+    res.status(200).type('json').set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
   });
 
   coverage['LROErrorPutAsyncInvalidJsonPolling'] = 0;
@@ -1244,12 +1244,12 @@ var lros = function (coverage) {
       'Location': pollingUri,
       'Retry-After': 0
     };
-    res.status(200).set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
+    res.status(200).type('json').set(headers).end('{ "properties": { "provisioningState": "Creating"}, "id": "100", "name": "foo" }');
   });
 
   router.get('/error/putasync/retry/failed/operationResults/invalidjsonpolling', function (req, res, next) {
     coverage['LROErrorPutAsyncInvalidJsonPolling']++;
-    res.status(200).end('{ "status": "Accepted"');
+    res.status(200).type('json').end('{ "status": "Accepted"');
   });
 
   coverage['LROErrorDeleteNoLocation'] = 0;
@@ -1282,7 +1282,7 @@ var lros = function (coverage) {
 
   router.get('/error/deleteasync/retry/failed/operationResults/nostatus', function (req, res, next) {
     coverage['LROErrorDeleteAsyncNoPollingStatus']++;
-    res.status(200).end('{ }');
+    res.status(200).type('json').end('{ }');
   });
 
   coverage['LROErrorDeleteAsyncInvalidHeader'] = 0;
@@ -1310,7 +1310,7 @@ var lros = function (coverage) {
 
   router.get('/error/deleteasync/retry/failed/operationResults/invalidjsonpolling', function (req, res, next) {
     coverage['LROErrorDeleteAsyncInvalidJsonPolling']++;
-    res.status(200).end('{ "status": "Accepted"');
+    res.status(200).type('json').end('{ "status": "Accepted"');
   });
 
   coverage['LROErrorPostNoLocation'] = 0;
@@ -1371,7 +1371,7 @@ var lros = function (coverage) {
 
   router.get('/error/postasync/retry/failed/operationResults/invalidjsonpolling', function (req, res, next) {
     coverage['LROErrorPostAsyncInvalidJsonPolling']++;
-    res.status(200).end('{ "status": "Accepted"');
+    res.status(200).type('json').end('{ "status": "Accepted"');
   });
 
   router.put('/customheader/putasync/retry/succeeded', function (req, res, next) {
@@ -1393,7 +1393,7 @@ var lros = function (coverage) {
     var header = req.get("x-ms-client-request-id");
     var scenario = 'CustomHeaderPutAsyncSucceded';
     if (header && header.toLowerCase() === "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0".toLowerCase()) {
-      res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
     } else {
       utils.send400(res, next, 'Did not receive the correct x-ms-client-request-id header in get: "' + header);
     }
@@ -1415,7 +1415,7 @@ var lros = function (coverage) {
       } else {
         removeScenarioCookie(res);
         coverage[scenario]++;
-        res.status(200).end('{ "status": "Succeeded"}');
+        res.status(200).type('json').end('{ "status": "Succeeded"}');
       }
     } else {
       utils.send400(res, next, 'Did not receive the correct x-ms-client-request-id header in get: "' + header);
@@ -1453,7 +1453,7 @@ var lros = function (coverage) {
       } else {
         removeScenarioCookie(res);
         coverage[scenario]++;
-        res.status(200).end('{ "status": "Succeeded"}');
+        res.status(200).type('json').end('{ "status": "Succeeded"}');
       }
     } else {
       utils.send400(res, next, 'Did not receive the correct x-ms-client-request-id header in get: "' + header);
@@ -1475,7 +1475,7 @@ var lros = function (coverage) {
     var header = req.get("x-ms-client-request-id");
     if (header && header.toLowerCase() === "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0".toLowerCase()) {
       coverage[scenario]++;
-      res.status(200).end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+      res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
     } else {
       utils.send400(res, next, 'Did not receive the correct x-ms-client-request-id header in get: "' + header);
     }

--- a/legacy/routes/model-flatten.js
+++ b/legacy/routes/model-flatten.js
@@ -32,7 +32,7 @@ var modelFlatten = function (coverage) {
           name: 'Resource3'
         }
       ];
-      res.status(200).end(JSON.stringify(result));
+      res.status(200).json(result);
     } else if (req.params.type === 'dictionary') {
       coverage['getModelFlattenDictionary']++;
       var result = {
@@ -59,7 +59,7 @@ var modelFlatten = function (coverage) {
           name: 'Resource3'
         }
       };
-      res.status(200).end(JSON.stringify(result));
+      res.status(200).json(result);
     } else if (req.params.type === 'resourcecollection') {
       coverage['getModelFlattenResourceCollection']++;
       var result = {
@@ -117,7 +117,7 @@ var modelFlatten = function (coverage) {
           location: 'Building 44'
         }
       };
-      res.status(200).end(JSON.stringify(result));
+      res.status(200).json(result);
     } else {
       utils.send400(res, next, "Request path must contain 'array', 'dictionary' or 'resourcecollection'");
     }
@@ -157,7 +157,7 @@ var modelFlatten = function (coverage) {
         'generic_value': "https://generic"
       }
     }
-  };                      
+  };
   router.put('/:type', function (req, res, next) {
     if (req.body) {
       if (req.params.type === 'array') {
@@ -184,7 +184,7 @@ var modelFlatten = function (coverage) {
       } else if (req.params.type === 'customFlattening') {
         if (_.isEqual(req.body, customFlattenBodyWithInheritedProperty)) {
           coverage['putModelFlattenCustomBase']++;
-          res.status(200).end(JSON.stringify(customFlattenBodyWithInheritedProperty));
+          res.status(200).json(customFlattenBodyWithInheritedProperty);
         } else {
           utils.send400(res, next, "The received body '" + JSON.stringify(req.body) + "' did not match the expected body '" + JSON.stringify(customFlattenBody) + "'.");
         }
@@ -199,7 +199,7 @@ var modelFlatten = function (coverage) {
       if (req.params.type === 'customFlattening') {
         if (_.isEqual(req.body, customFlattenBody)) {
           coverage['postModelFlattenCustomParameter']++;
-          res.status(200).end(JSON.stringify(customFlattenBody));
+          res.status(200).json(customFlattenBody);
         } else {
           utils.send400(res, next, "The received body '" + JSON.stringify(req.body) + "' did not match the expected body '" + JSON.stringify(customFlattenBody) + "'.");
         }
@@ -213,9 +213,9 @@ var modelFlatten = function (coverage) {
     if (req.body) {
       if (_.isEqual(req.body, customFlattenBody) && req.params.name === 'groupproduct') {
         coverage['putModelFlattenCustomGroupedParameter']++;
-        res.status(200).end(JSON.stringify(customFlattenBody));
+        res.status(200).json(customFlattenBody);
       } else {
-        utils.send400(res, next, "The received body '" + JSON.stringify(req.body) + "' did not match the expected body '" + JSON.stringify(customFlattenBody) + 
+        utils.send400(res, next, "The received body '" + JSON.stringify(req.body) + "' did not match the expected body '" + JSON.stringify(customFlattenBody) +
           "'. Or the path parameter name does not have the value 'groupproduct'");
       }
     } else {

--- a/legacy/routes/number.js
+++ b/legacy/routes/number.js
@@ -47,33 +47,33 @@ var number = function(coverage, optCoverage) {
         if (req.params.format === 'float') {
             if (req.params.value === '3.402823e+20') {
                 coverage['getFloatBigScientificNotation']++;
-                res.status(200).end('3.402823e+20');
+                res.status(200).type('json').end('3.402823e+20');
             } else {
                 utils.send400(res, next, "Did not like the value provided for big float in the req " + util.inspect(req.params.value));
             }
         } else if (req.params.format === 'double') {
             if (req.params.value === '2.5976931e+101') {
                 coverage['getDoubleBigScientificNotation']++;
-                res.status(200).end('2.5976931e+101');
+                res.status(200).type('json').end('2.5976931e+101');
             } else if (req.params.value === '99999999.99') {
                 coverage['getDoubleBigPositiveDecimal']++;
-                res.status(200).end('99999999.99');
+                res.status(200).type('json').end('99999999.99');
             } else if (req.params.value === '-99999999.99') {
                 coverage['getDoubleBigNegativeDecimal']++;
-                res.status(200).end('-99999999.99');
+                res.status(200).type('json').end('-99999999.99');
             } else {
                 utils.send400(res, next, "Did not understand the value provided for big double in the req " + util.inspect(req.params.value));
             }
 		} else if (req.params.format === 'decimal') {
             if (req.params.value === '2.5976931e+101') {
                 optCoverage['getDecimalBig']++;
-                res.status(200).end('2.5976931e+101');
+                res.status(200).type('json').end('2.5976931e+101');
             } else if (req.params.value === '99999999.99') {
                 optCoverage['getDecimalBigPositiveDecimal']++;
-                res.status(200).end('99999999.99');
+                res.status(200).type('json').end('99999999.99');
             } else if (req.params.value === '-99999999.99') {
                 optCoverage['getDecimalBigNegativeDecimal']++;
-                res.status(200).end('-99999999.99');
+                res.status(200).type('json').end('-99999999.99');
             } else {
                 utils.send400(res, next, "Did not understand the value provided for big decimal in the req " + util.inspect(req.params.value));
             }
@@ -113,21 +113,21 @@ var number = function(coverage, optCoverage) {
         if (req.params.format === 'float') {
             if (req.params.value === '3.402823e-20') {
                 coverage['getFloatSmallScientificNotation']++;
-                res.status(200).end('3.402823e-20');
+                res.status(200).type('json').end('3.402823e-20');
             } else {
                 utils.send400(res, next, "Did not like the value provided for small float in the req " + util.inspect(req.params.value));
             }
         } else if (req.params.format === 'double') {
             if (req.params.value === '2.5976931e-101') {
                 coverage['getDoubleSmallScientificNotation']++;
-                res.status(200).end('2.5976931e-101');
+                res.status(200).type('json').end('2.5976931e-101');
             } else {
                 utils.send400(res, next, "Did not like the value provided for small double in the req " + util.inspect(req.params.value));
             }
 		} else if (req.params.format === 'decimal') {
             if (req.params.value === '2.5976931e-101') {
                 optCoverage['getDecimalSmall']++;
-                res.status(200).end('2.5976931e-101');
+                res.status(200).type('json').end('2.5976931e-101');
             } else {
                 utils.send400(res, next, "Did not like the value provided for small decimal in the req " + util.inspect(req.params.value));
             }
@@ -142,13 +142,13 @@ var number = function(coverage, optCoverage) {
             res.status(200).end();
         } else if (req.params.scenario === 'invalidfloat') {
             coverage['getFloatInvalid']++;
-            res.status(200).end('2147483656.090096789909j');
+            res.status(200).type('json').end('2147483656.090096789909j');
         } else if (req.params.scenario === 'invaliddouble') {
             coverage['getDoubleInvalid']++;
-            res.status(200).end('9223372036854775910.980089k');
+            res.status(200).type('json').end('9223372036854775910.980089k');
 		} else if (req.params.scenario === 'invaliddecimal') {
 			optCoverage['getDecimalInvalid']++;
-            res.status(200).end('9223372036854775910.980089k');
+            res.status(200).type('json').end('9223372036854775910.980089k');
         } else {
             res.status(400).send('Request path must contain true or false');
         }

--- a/legacy/routes/paging.js
+++ b/legacy/routes/paging.js
@@ -47,58 +47,58 @@ var paging = function(coverage) {
 
   router.get('/noitemname', function(req, res, next) {
     coverage["PagingNoItemName"]++;
-    res.status(200).end('{ "value" : [ {"properties":{"id": 1, "name": "Product" }}]}');
+    res.status(200).json({ "value" : [ {"properties":{"id": 1, "name": "Product" }}]});
   });
 
   router.get('/nullnextlink', function(req, res, next) {
     coverage["PagingNextLinkNameNull"]++;
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"' + 'http://localhost:' + utils.getPort() + '/paging/idontexistraise404" }')
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"http://localhost:" + utils.getPort() + "/paging/idontexistraise404" });
   });
 
   router.get('/single', function(req, res, next) {
     coverage["PagingSingle"]++;
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}]}');
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}]});
   });
 
   router.get('/multiple', function(req, res, next) {
 
     coverage["PagingMultiple"]++;
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"' + 'http://localhost:' + utils.getPort() + '/paging/multiple/page/2" }')
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"http://localhost:" + utils.getPort() + "/paging/multiple/page/2" });
   });
 
   router.get('/multiple/page/:pagenumber', function(req, res, next) {
     if (req.params.pagenumber < 10) {
-      res.status(200).end('{ "values": [ {"properties":{"id" : ' + req.params.pagenumber + ', "name": "product"}} ], "nextLink": "' + 'http://localhost:' + utils.getPort() + '/paging/multiple/page/' + (++req.params.pagenumber) + '"}');
+      res.status(200).json({ "values": [ {"properties":{"id" : req.params.pagenumber, "name": "product"}} ], "nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/page/" + (++req.params.pagenumber) });
     } else {
-      res.status(200).end('{"values": [ {"properties":{"id" : ' + req.params.pagenumber + ', "name": "product"}} ]}');
+      res.status(200).json({"values": [ {"properties":{"id" : req.params.pagenumber, "name": "product"}} ]});
     }
   });
 
   router.get('/multiple/odata', function(req, res, next) {
 
     coverage["PagingOdataMultiple"]++;
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "odata.nextLink":"' + 'http://localhost:' + utils.getPort() + '/paging/multiple/odata/page/2" }')
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "odata.nextLink":"http://localhost:" + utils.getPort() + "/paging/multiple/odata/page/2" });
   });
 
   router.get('/multiple/odata/page/:pagenumber', function(req, res, next) {
     if (req.params.pagenumber < 10) {
-      res.status(200).end('{ "values": [ {"properties":{"id" : ' + req.params.pagenumber + ', "name": "product"}} ], "odata.nextLink": "' + 'http://localhost:' + utils.getPort() + '/paging/multiple/odata/page/' + (++req.params.pagenumber) + '"}');
+      res.status(200).json({ "values": [ {"properties":{"id" : req.params.pagenumber, "name": "product"}} ], "odata.nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/odata/page/" + (++req.params.pagenumber) });
     } else {
-      res.status(200).end('{"values": [ {"properties":{"id" : ' + req.params.pagenumber + ', "name": "product"}} ]}');
+      res.status(200).json({"values": [ {"properties":{"id" : req.params.pagenumber, "name": "product"}} ]});
     }
   });
 
   router.get('/multiple/withpath/:offset', function(req, res, next) {
 
     coverage["PagingMultiplePath"]++;
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"' + 'http://localhost:' + utils.getPort() + '/paging/multiple/withpath/page/' + req.params.offset + '/2" }');
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"http://localhost:" + utils.getPort() + "/paging/multiple/withpath/page/' + req.params.offset + '/2" });
   });
 
   router.get('/multiple/withpath/page/:offset/:pagenumber', function(req, res, next) {
     if (req.params.pagenumber < 10) {
-      res.status(200).end('{ "values": [ {"properties":{"id" : ' + (parseInt(req.params.pagenumber) + parseInt(req.params.offset)) + ', "name": "product"}} ], "nextLink": "' + 'http://localhost:' + utils.getPort() + '/paging/multiple/withpath/page/' + req.params.offset + "/" + (++req.params.pagenumber) + '"}');
+      res.status(200).json({ "values": [ {"properties":{"id" : parseInt(req.params.pagenumber) + parseInt(req.params.offset), "name": "product"}} ], "nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/withpath/page/" + req.params.offset + "/" + ++req.params.pagenumber});
     } else {
-      res.status(200).end('{"values": [ {"properties":{"id" : ' + (parseInt(req.params.pagenumber) + parseInt(req.params.offset)) + ', "name": "product"}} ]}');
+      res.status(200).json({"values": [ {"properties":{"id" : parseInt(req.params.pagenumber) + parseInt(req.params.offset), "name": "product"}} ]});
     }
   });
 
@@ -110,12 +110,12 @@ var paging = function(coverage) {
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "' + 'http://localhost:' + utils.getPort() + '/paging/multiple/page/2" }')
+      res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/page/2" });
     }
   });
 
   router.get('/multiple/retrysecond', function(req, res, next) {
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "' + 'http://localhost:' + utils.getPort() + '/paging/multiple/retrysecond/page/2" }')
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/retrysecond/page/2" });
   });
 
   router.get('/multiple/retrysecond/page/:pagenumber', function(req, res, next) {
@@ -127,12 +127,12 @@ var paging = function(coverage) {
       } else {
         coverage[scenario]++;
         removeScenarioCookie(res);
-        res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "' + 'http://localhost:' + utils.getPort() + '/paging/multiple/retrysecond/page/3" }')
+        res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/retrysecond/page/3" });
       }
     } else if (req.params.pagenumber < 10) {
-      res.status(200).end('{ "values": [ {"properties":{"id" : ' + req.params.pagenumber + ', "name": "product"}} ], "nextLink": "' + 'http://localhost:' + utils.getPort() + '/paging/multiple/retrysecond/page/' + (++req.params.pagenumber) + '"}');
+      res.status(200).json({ "values": [ {"properties":{"id" : req.params.pagenumber, "name": "product"}} ], "nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/retrysecond/page/" + (++req.params.pagenumber)});
     } else {
-      res.status(200).end('{"values": [ {"properties":{"id" : ' + req.params.pagenumber + ', "name": "product"}} ]}');
+      res.status(200).json({"values": [ {"properties":{"id" : req.params.pagenumber, "name": "product"}} ]});
     }
   });
 
@@ -141,7 +141,7 @@ var paging = function(coverage) {
       res.status(400).end("Required path and query parameters are not present");
     }
     else {
-      res.status(200).end('{ "values": [ {"properties":{"id" : 1, "name": "product"}} ], "odata.nextLink": "next?page=2"}');
+      res.status(200).json({ "values": [ {"properties":{"id" : 1, "name": "product"}} ], "odata.nextLink": "next?page=2"});
     }
   });
 
@@ -150,11 +150,11 @@ var paging = function(coverage) {
       res.status(400).end("Required path and query parameters are not present");
     }
     else if(req.query.page < 10) {
-      res.status(200).end('{ "values": [ {"properties":{"id" : ' + req.query.page + ', "name": "product"}} ], "odata.nextLink": "next?page=' + ++req.query.page + '"}');
+      res.status(200).json({ "values": [ {"properties":{"id" : req.query.page, "name": "product"}} ], "odata.nextLink": "next?page=" + ++req.query.page});
     }
     else {
       coverage["PagingFragment"]++;
-      res.status(200).end('{"values": [ {"properties":{"id" : ' + req.query.page + ', "name": "product"}} ]}');
+      res.status(200).json({"values": [ {"properties":{"id" : req.query.page, "name": "product"}} ]});
     }
   });
 
@@ -163,7 +163,7 @@ var paging = function(coverage) {
       res.status(400).end("Required path and query parameters are not present");
     }
     else {
-      res.status(200).end('{ "values": [ {"properties":{"id" : 1, "name": "product"}} ], "odata.nextLink": "next?page=2"}');
+      res.status(200).json({ "values": [ {"properties":{"id" : 1, "name": "product"}} ], "odata.nextLink": "next?page=2"});
     }
   });
 
@@ -172,10 +172,10 @@ var paging = function(coverage) {
       res.status(400).end("Required path and query parameters are not present");
     }
     else if(req.query.page < 10) {
-      res.status(200).end('{ "values": [ {"properties":{"id" : ' + req.query.page + ', "name": "product"}} ], "odata.nextLink": "next?page=' + ++req.query.page + '"}');
+      res.status(200).json({ "values": [ {"properties":{"id" : req.query.page, "name": "product"}} ], "odata.nextLink": "next?page=" + ++req.query.page});
     }
     else {
-      res.status(200).end('{"values": [ {"properties":{"id" : ' + req.query.page + ', "name": "product"}} ]}');
+      res.status(200).json({"values": [ {"properties":{"id" : req.query.page, "name": "product"}} ]});
     }
   });
 
@@ -187,51 +187,51 @@ var paging = function(coverage) {
       'Location': 'http://localhost:' + utils.getPort() + '/paging/multiple',
       'Retry-After': 0
     };
-    res.set(headers).status(202).end('{ "status": "Accepted"}');
+    res.set(headers).status(202).json({ "status": "Accepted"});
   });
 
   router.get('/multiple/lro/200', function (req, res, next) {
     coverage['PagingMultipleLRO']++;
-    res.status(200).end('{ "status": "Succeeded"}');
+    res.status(200).json({ "status": "Succeeded"});
   });
 
   /*** NEGATIVE TESTS HERE ***/
   router.get('/single/failure', function(req, res, next) {
     coverage["PagingSingleFailure"]++;
-    res.status(400).end('{"status": 400, "message": "Expected single failure test."}');
+    res.status(400).json({"status": 400, "message": "Expected single failure test."});
   });
 
   router.get('/multiple/failure', function(req, res, next) {
     coverage["PagingMultipleFailure"]++;
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "' + 'http://localhost:' + utils.getPort() + '/paging/multiple/failure/page/2" }')
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/failure/page/2" });
   });
 
   router.get('/multiple/failure/page/:pagenumber', function(req, res, next) {
-    res.status(400).end('{"status": 400, "message": "Expected single failure test."}');
+    res.status(400).json({"status": 400, "message": "Expected single failure test."});
   });
 
   router.get('/multiple/failureuri', function(req, res, next) {
     coverage["PagingMultipleFailureUri"]++;
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "*&*#&$" }')
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "*&*#&$" });
   });
 
   /** CUSTOM URL **/
   router.get('/customurl/partialnextlink', function(req, res, next) {
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "/paging/customurl/partialnextlink/page/2" }')
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "/paging/customurl/partialnextlink/page/2" });
   });
 
   router.get('/customurl/partialnextlink/page/2', function(req, res, next) {
     coverage["PagingCustomUrlPartialNextLink"]++;
-    res.status(200).end('{ "values" : [ {"properties":{"id": 2, "name": "Product" }}]}');
+    res.status(200).json({ "values" : [ {"properties":{"id": 2, "name": "Product" }}]});
   });
 
   router.get('/customurl/partialnextlinkop', function(req, res, next) {
-    res.status(200).end('{ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "partialnextlinkop/page/2" }')
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink": "partialnextlinkop/page/2" });
   });
 
   router.get('/customurl/partialnextlinkop/page/2', function(req, res, next) {
     coverage["PagingCustomUrlPartialOperationNextLink"]++;
-    res.status(200).end('{ "values" : [ {"properties":{"id": 2, "name": "Product" }}]}');
+    res.status(200).json({ "values" : [ {"properties":{"id": 2, "name": "Product" }}]});
   });
 
 };

--- a/legacy/routes/report.js
+++ b/legacy/routes/report.js
@@ -22,17 +22,17 @@ const report = function(coverage, azureCoverage, optionalCoverage) {
 
   router.get('/', function(req, res, next) {
     writeOutCoverageReport(`../coverage/report-vanilla${getQualifiedSuffix(req)}`, coverage);
-    res.status(200).end(JSON.stringify(coverage));
+    res.status(200).json(coverage);
   });
 
   router.get('/azure', function(req, res, next) {
     writeOutCoverageReport(`../coverage/report-azure${getQualifiedSuffix(req)}`, azureCoverage);
-    res.status(200).end(JSON.stringify(azureCoverage));
+    res.status(200).json(azureCoverage);
   });
 
   router.get('/optional', function(req, res, next) {
     writeOutCoverageReport(`../coverage/report-optional${getQualifiedSuffix(req)}`, optionalCoverage);
-    res.status(200).end(JSON.stringify(optionalCoverage));
+    res.status(200).json(optionalCoverage);
   });
 }
 

--- a/legacy/routes/reqopt.js
+++ b/legacy/routes/reqopt.js
@@ -23,11 +23,11 @@ var reqopt = function (coverage) {
   coverage['OptionalArrayProperty'] = 0;
   coverage['OptionalArrayHeader'] = 0;
   coverage['OptionalGlobalQuery'] = 0;
-  
+
   router.get('/implicit/required/path/:pathParameter', function (req, res, next) {
     utils.send400(res, next, 'Client library failed to throw when an implicitly required path parameter is not provided.');
   });
-  
+
   router.put('/implicit/optional/:scenario', function (req, res, next) {
     if (req.params.scenario === 'query') {
       if (!req.query.queryParameter) {
@@ -54,11 +54,11 @@ var reqopt = function (coverage) {
       utils.send400(res, next, 'Must specify either it\'s "required" or "optional", "' + req.params.required + '" provided.');
     }
   });
-  
+
   router.put('/required/:type/:scenario', function (req, res, next) {
     utils.send400(res, next, 'Client library failed to throw when a required value type is not provided.');
   });
-  
+
   router.post('/optional/:type/:scenario', function (req, res, next) {
     var covered = "Optional" + utils.toPascalCase(req.params.type) + utils.toPascalCase(req.params.scenario);
     console.log('scenario: ' + covered + '\n');
@@ -85,24 +85,24 @@ var reqopt = function (coverage) {
       }
     } else if (req.params.scenario === 'response') {
       coverage[covered]++;
-      res.status(200).end('null');
+      res.status(200).type('json').end('null');
     } else if (req.params.scenario === 'responseProperty') {
       coverage[covered]++;
-      res.status(200).end('{"value": null }');
+      res.status(200).type('json').end('{"value": null }');
     } else if (req.params.scenario === 'responseHeader') {
       coverage[covered]++;
-      res.status(200).set('value', null).end();
+      res.status(200).type('json').set('value', null).end();
     }
   });
-  
+
   router.get('/global/required/path/:required_global_path', function (req, res, next) {
     utils.send400(res, next, 'Client library failed to throw when an implicitly required path parameter is not provided.');
   });
-  
+
   router.get('/global/required/query', function (req, res, next) {
     utils.send400(res, next, 'Client library failed to throw when an explicitly required query parameter is not provided.');
   });
-  
+
   router.get('/global/optional/query', function (req, res, next) {
     if (!req.query.optional_global_query) {
       coverage["OptionalGlobalQuery"]++;

--- a/legacy/routes/string.js
+++ b/legacy/routes/string.js
@@ -8,12 +8,12 @@ var string = function (coverage) {
   var base64String    = "YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjQ=";
   var base64UrlString = "YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw";
   var RefColorConstant = { "field1": "Sample String" };
-  
+
   router.put('/:scenario', function (req, res, next) {
     if (req.params.scenario === 'null') {
       if (req.body === undefined || (req.body && Object.keys(req.body).length === 0 && req.headers['content-length'] === '0')) {
         coverage['putStringNull']++;
-        res.status(200).end(); 
+        res.status(200).end();
       } else {
         utils.send400(res, next, "Did not like null req '" + util.inspect(req) + "'");
       }
@@ -50,17 +50,17 @@ var string = function (coverage) {
       utils.send400(res, next, 'Request path must contain true or false');
     }
   });
-  
+
   router.get('/:scenario', function (req, res, next) {
     if (req.params.scenario === 'null') {
       coverage['getStringNull']++;
       res.status(200).end();
     } else if (req.params.scenario === 'base64Encoding') {
       coverage['getStringBase64Encoded']++;
-      res.status(200).end('"' + base64String + '"');
+      res.status(200).type('json').end('"' + base64String + '"');
     } else if (req.params.scenario === 'base64UrlEncoding') {
       coverage['getStringBase64UrlEncoded']++;
-      res.status(200).end('"' + base64UrlString + '"');
+      res.status(200).type('json').end('"' + base64UrlString + '"');
     } else if (req.params.scenario === 'nullBase64UrlEncoding') {
       coverage['getStringNullBase64UrlEncoding']++;
       res.status(200).end();
@@ -69,24 +69,24 @@ var string = function (coverage) {
       res.status(200).end();
     } else if (req.params.scenario === 'empty') {
       coverage['getStringEmpty']++;
-      res.status(200).end('\"\"');
+      res.status(200).type('json').end('\"\"');
     } else if (req.params.scenario === 'mbcs') {
       coverage['getStringMultiByteCharacters']++;
-      res.status(200).end('"' + constants.MULTIBYTE_BUFFER_BODY + '"');
+      res.status(200).type('json').end('"' + constants.MULTIBYTE_BUFFER_BODY + '"');
     } else if (req.params.scenario === 'whitespace') {
       coverage['getStringWithLeadingAndTrailingWhitespace']++;
-      res.status(200).end('\"    Now is the time for all good men to come to the aid of their country    \"');
+      res.status(200).type('json').end('\"    Now is the time for all good men to come to the aid of their country    \"');
     } else {
       res.status(400).end('Request path must contain null or empty or mbcs or whitespace');
     }
 
   });
-  
+
   router.get('/enum/notExpandable', function (req, res, next) {
     coverage['getEnumNotExpandable']++;
-    res.status(200).end('"red color"');
+    res.status(200).type('json').end('"red color"');
   });
-  
+
   router.put('/enum/notExpandable', function (req, res, next) {
     if (req.body === 'red color') {
       coverage['putEnumNotExpandable']++;
@@ -97,9 +97,9 @@ var string = function (coverage) {
 	});
    router.get('/enum/notExpandable', function (req, res, next) {
     coverage['getEnumNotExpandable']++;
-    res.status(200).end('"red color"');
+    res.status(200).type('json').end('"red color"');
   });
-  
+
   router.put('/enum/notExpandable', function (req, res, next) {
     if (req.body === 'red color') {
       coverage['putEnumNotExpandable']++;
@@ -110,7 +110,7 @@ var string = function (coverage) {
     });
     router.get('/enum/Referenced', function (req, res, next) {
       coverage['getEnumReferenced']++;
-      res.status(200).end('"red color"');
+      res.status(200).type('json').end('"red color"');
     });
 
     router.put('/enum/Referenced', function (req, res, next) {
@@ -123,7 +123,7 @@ var string = function (coverage) {
     });
     router.get('/enum/ReferencedConstant', function (req, res, next) {
       coverage['getEnumReferencedConstant']++;
-      res.status(200).end(JSON.stringify(RefColorConstant));
+      res.status(200).json(RefColorConstant);
     });
 
     router.put('/enum/ReferencedConstant', function (req, res, next) {

--- a/legacy/routes/validation.js
+++ b/legacy/routes/validation.js
@@ -12,14 +12,14 @@ var specials = function (coverage) {
       coverage["ConstantsInPath"]++;
       res.status(200).end();
   });
-  
+
   router.post('/constantsInPath/constant/value', function (req, res, next) {
-    if (req.body && req.body.constString === 'constant' && req.body.constInt === 0 
-        && req.body.child && req.body.child.constProperty === 'constant' 
+    if (req.body && req.body.constString === 'constant' && req.body.constInt === 0
+        && req.body.child && req.body.child.constProperty === 'constant'
         && req.body.constChild.constProperty === 'constant'
         && req.body.constChild.constProperty2 === 'constant2') {
         coverage["ConstantsInBody"]++;
-        res.status(200).end(JSON.stringify(req.body));
+        res.status(200).json(req.body);
       } else {
         utils.send400(res, next, "Constant values were not present in the body '" + util.inspect(req.body) + "'");
       }

--- a/legacy/routes/xml.js
+++ b/legacy/routes/xml.js
@@ -576,7 +576,7 @@ var xmlService = function (coverage) {
 
   router.get('/jsonoutput', function (req, res, next) {
     coverage['jsonOutputInXMLSwagger']++;
-    res.status(200).end('{ "id": 42 }');
+    res.status(200).json({ "id": 42 });
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
Current testserver doesn't set Content-Type at all, and there is several problems with that:
- If our runtime might use this information, we don't test that (Python does use it, and we have a special hack for the testserver...)
- Wiremock recordings don't know it's readable, so [saves the recording as base64](https://github.com/Azure/autorest.testserver/blob/f88f537120cfc2b1927bdb0f2aede5eaa140a028/mappings/azure/paging_multiple_page_2-0e479f5b-81a9-4dce-8d75-c295e745106f.json#L10), which makes the recording impossible to read and update (like updating the absolute link of paging to use "baseUrl" @MiYanni )

That's a cumbersome work, but I think it's necessary. Anyone feel free to participate :)