### PR TITLE
Allow for dynamic port in paging tests

### DIFF
--- a/legacy/app.js
+++ b/legacy/app.js
@@ -42,7 +42,7 @@ var additionalProperties = require('./routes/additionalProperties.js');
 var coverageEndpoint = require('./coverage/coverageEndpoint.js');
 
 var xml = require('./routes/xml.js'); // XML serialization
-var util = require('util');
+var utils = require('./util/utils.js');
 var cors = require('cors');
 var app = express();
 
@@ -560,6 +560,10 @@ app.use(function(req, res, next) {
 app.use(function(err, req, res, next) {
   res.status(err.status || 500);
   res.end(JSON.stringify(err));
+});
+
+var listener = app.listen(process.env.PORT || 3000, function() {
+  utils.setPort(listener.address().port);
 });
 
 module.exports = app;

--- a/legacy/util/utils.js
+++ b/legacy/util/utils.js
@@ -1,3 +1,6 @@
+var express = require('express');
+
+var listeningPort = 0;
 
 exports = module.exports;
 
@@ -15,8 +18,13 @@ exports.coerceDate = function(targetObject) {
   return JSON.parse(stringRep);
 };
 
+exports.setPort = function(port)
+{
+  listeningPort = port;
+}
+
 exports.getPort = function () {
-	return process.env.PORT || 3000;
+	return listeningPort;
 }
 
 exports.toPascalCase = function(input) {

--- a/legacy/util/utils.js
+++ b/legacy/util/utils.js
@@ -1,6 +1,6 @@
 var express = require('express');
 
-var listeningPort = 0;
+var serverPort = 0;
 
 exports = module.exports;
 
@@ -20,11 +20,11 @@ exports.coerceDate = function(targetObject) {
 
 exports.setPort = function(port)
 {
-  listeningPort = port;
+  serverPort = port;
 }
 
 exports.getPort = function () {
-	return listeningPort;
+	return serverPort;
 }
 
 exports.toPascalCase = function(input) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
In .net we start the test server on a random port. Support this scenario by getting port from express instead of env variable.