### PR TITLE
Allow skipping GitHub comment in coverage run if token is "skip"

### DIFF
--- a/legacy/coverage/coverage.js
+++ b/legacy/coverage/coverage.js
@@ -49,7 +49,7 @@ async function collectCoverage() {
         }
         comment += "\n\n";
     }
-    
+
     const testServerVersion = require(join(coverageFolder, "..", "package.json")).version;
     return `${commentIndicatorCoverage}# 🤖 AutoRest automatic feature coverage report 🤖\n*feature set version ${testServerVersion}*\n\n${comment}`;
 }
@@ -95,6 +95,11 @@ async function push(repo, pr, token, azStorageAccount, azStorageAccessKey) {
 }
 
 async function immediatePush(repo, ref, githubToken, azStorageAccount, azStorageAccessKey) {
+    if (!githubToken || githubToken === "skip") {
+      console.log("Skipping GitHub comment")
+      return;
+    }
+
     // try posting "published" comment on GitHub (IMPORTANT: this assumes that this script is only run after successful publish!)
     try {
         // try deriving PR associated with last commit


### PR DESCRIPTION
This should unblock https://github.com/Azure/autorest.python/pull/492 so that a GitHub token isn't needed to publish coverage results.