### PR TITLE
Fix relative paths used for checking package versions

### DIFF
--- a/legacy/coverage/coverage.js
+++ b/legacy/coverage/coverage.js
@@ -50,11 +50,11 @@ async function collectCoverage() {
         comment += "\n\n";
     }
 
-    const testServerVersion = require(join(coverageFolder, "..", "package.json")).version;
+    const testServerVersion = require(join(coverageFolder, "..", "..", "package.json")).version;
     return `${commentIndicatorCoverage}# 🤖 AutoRest automatic feature coverage report 🤖\n*feature set version ${testServerVersion}*\n\n${comment}`;
 }
 function getPublishedPackageVersion() {
-    return require(join(__dirname, "..", "..", "..", "..", "package.json")).version;
+    return require(join(__dirname, "..", "..", "..", "..", "..", "package.json")).version;
 }
 async function pushCoverage(repo, ref, azStorageAccount, azStorageAccessKey, comment) {
     const version = getPublishedPackageVersion();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.11",
+  "version": "2.10.12",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
This change fixes some relative paths that were invalidated with the move of code coverage scripts into the `legacy` folder.  Needed to unblock https://github.com/Azure/autorest.python/pull/492