### PR TITLE
Removing invalid enums in body-string swagger

### DIFF
--- a/swagger/body-string.json
+++ b/swagger/body-string.json
@@ -73,8 +73,7 @@
           "200": {
             "description": "The empty String value",
             "schema": {
-              "type": "string",
-              "enum": [ "" ]
+              "type": "string"
             }
           },
           "default": {
@@ -93,8 +92,7 @@
             "name": "stringBody",
             "in": "body",
             "schema": {
-              "type": "string",
-              "enum": [ "" ]
+              "type": "string"
             },
             "required": true
           }

--- a/swagger/body-string.json
+++ b/swagger/body-string.json
@@ -23,8 +23,7 @@
           "200": {
             "description": "The null String value",
             "schema": {
-              "type": "string",
-              "enum": [ null ]
+              "type": "string"
             }
           },
           "default": {
@@ -43,8 +42,7 @@
             "name": "stringBody",
             "in": "body",
             "schema": {
-              "type": "string",
-              "enum": [ null ]
+              "type": "string"
             }
           }
         ],


### PR DESCRIPTION
Removing null and empty string enums from body string group. 