### PR TITLE
Add optional version param to coverage commands

### DIFF
--- a/legacy/coverage/app-immediate-push.js
+++ b/legacy/coverage/app-immediate-push.js
@@ -1,6 +1,6 @@
 const { immediatePush } = require("./coverage");
-const { repo, pr, githubToken, azStorageAccount, azStorageAccessKey } = require("./cli");
+const { repo, pr, githubToken, azStorageAccount, azStorageAccessKey, version } = require("./cli");
 
 Promise.resolve()
-    .then(_ => immediatePush(repo, pr, githubToken, azStorageAccount, azStorageAccessKey))
+    .then(_ => immediatePush(repo, pr, githubToken, azStorageAccount, azStorageAccessKey, version))
     .catch(x => { console.error(x); });

--- a/legacy/coverage/cli.js
+++ b/legacy/coverage/cli.js
@@ -17,6 +17,7 @@ const ref = args[1];
 const githubToken = args[2];
 const azStorageAccount = args[3];
 const azStorageAccessKey = args[4];
+const version = args[5];
 if (!repo || !ref || !githubToken) throw "too few arguments";
 
 const pr = ref.split('/')[2];
@@ -27,5 +28,6 @@ module.exports = {
     githubToken,
     azStorageAccount,
     azStorageAccessKey,
-    pr
+    pr,
+    version
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.18",
+  "version": "2.10.19",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
Allow specifying a generator version when publishing test server
coverage.  If no version is specified, use previous behavior.