### PR TITLE
Remove pre-declaration of FormData tests

### DIFF
--- a/legacy/app.js
+++ b/legacy/app.js
@@ -457,8 +457,6 @@ var coverage = {
   "HeaderResponseDateTimeRfc1123Min": 0,
   "HeaderResponseBytesValid": 0,
   "HeaderResponseDurationValid": 0,
-  "FormdataStreamUploadFile": 0,
-  "StreamUploadFile": 0,
   "ConstantsInPath": 0,
   "ConstantsInBody": 0,
   "CustomBaseUri": 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.23",
+  "version": "2.10.24",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
It doesn't server any purpose, since this is declared in the formData file itself, and broke 2.10.23....