### PR TITLE
Add paging operation with query params

### DIFF
--- a/legacy/routes/paging.js
+++ b/legacy/routes/paging.js
@@ -83,7 +83,7 @@ var paging = function(coverage) {
       res.status(200).json({ "values" : [ {"properties":{"id": 2, "name": "Product" }}]});
     }
     else{
-        utils.send400(res, next, 'The query parameters to getWithQueryParams were not passed correctly');
+        utils.send400(res, next, 'The query parameters to nextOperationWithQueryParams were not passed correctly');
     }
   });
 

--- a/legacy/routes/paging.js
+++ b/legacy/routes/paging.js
@@ -95,14 +95,6 @@ var paging = function(coverage) {
     }
   });
 
-  router.get('/multiple/page/:pagenumber', function(req, res, next) {
-    if (req.params.pagenumber < 10) {
-      res.status(200).json({ "values": [ {"properties":{"id" : parseInt(req.params.pagenumber), "name": "product"}} ], "nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/page/" + (++req.params.pagenumber) });
-    } else {
-      res.status(200).json({"values": [ {"properties":{"id" : parseInt(req.params.pagenumber), "name": "product"}} ]});
-    }
-  });
-
   router.get('/multiple/odata', function(req, res, next) {
 
     coverage["PagingOdataMultiple"]++;

--- a/legacy/routes/paging.js
+++ b/legacy/routes/paging.js
@@ -33,8 +33,7 @@ var paging = function(coverage) {
   coverage["PagingNextLinkNameNull"] = 0;
   coverage['PagingSingle'] = 0;
   coverage['PagingMultiple'] = 0;
-  coverage['PagingMultipleWithQueryParametersInitialFunction'] = 0;
-  coverage['PagingMultipleWithQueryParametersNextFunction'] = 0;
+  coverage['PagingMultipleWithQueryParameters'] = 0;
   coverage['PagingOdataMultiple'] = 0;
   coverage['PagingMultiplePath'] = 0;
   coverage['PagingMultipleRetryFirst'] = 0;
@@ -69,9 +68,9 @@ var paging = function(coverage) {
   });
 
   router.get('/multiple/getWithQueryParams', function(req, res, next) {
+    // No coverage added here, gets added in next operation nextOperatoinWithQueryParams
     if (req.query['requiredQueryParameter'] == '100' && req.query['optionalQueryParameter'] == 'optional') {
-      coverage["PagingMultipleWithQueryParametersInitialFunction"]++;
-    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"http://localhost:" + utils.getPort() + "/paging/multiple/nextOperationWithQueryParams" });
+      res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"http://localhost:" + utils.getPort() + "/paging/multiple/nextOperationWithQueryParams" });
     }
     else{
         utils.send400(res, next, 'The query parameters to getWithQueryParams were not passed correctly');
@@ -80,7 +79,7 @@ var paging = function(coverage) {
 
   router.get('/multiple/nextOperationWithQueryParams', function(req, res, next) {
     if (Object.keys(req.query).length <= 1 && req.query['next'] === 'true') {
-      coverage["PagingMultipleWithQueryParametersNextFunction"]++;
+      coverage["PagingMultipleWithQueryParameters"]++;
       res.status(200).json({ "values" : [ {"properties":{"id": 2, "name": "Product" }}]});
     }
     else{

--- a/legacy/routes/paging.js
+++ b/legacy/routes/paging.js
@@ -69,7 +69,7 @@ var paging = function(coverage) {
 
   router.get('/multiple/getWithQueryParams', function(req, res, next) {
     // No coverage added here, gets added in next operation nextOperationWithQueryParams
-    if (req.query['requiredQueryParameter'] == '100') {
+    if (req.query['requiredQueryParameter'] == '100' && req.query['queryConstant'] == 'true') {
       res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"http://localhost:" + utils.getPort() + "/paging/multiple/nextOperationWithQueryParams" });
     }
     else{

--- a/legacy/routes/paging.js
+++ b/legacy/routes/paging.js
@@ -68,8 +68,8 @@ var paging = function(coverage) {
   });
 
   router.get('/multiple/getWithQueryParams', function(req, res, next) {
-    // No coverage added here, gets added in next operation nextOperatoinWithQueryParams
-    if (req.query['requiredQueryParameter'] == '100' && req.query['optionalQueryParameter'] == 'optional') {
+    // No coverage added here, gets added in next operation nextOperationWithQueryParams
+    if (req.query['requiredQueryParameter'] == '100') {
       res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"http://localhost:" + utils.getPort() + "/paging/multiple/nextOperationWithQueryParams" });
     }
     else{
@@ -78,7 +78,7 @@ var paging = function(coverage) {
   });
 
   router.get('/multiple/nextOperationWithQueryParams', function(req, res, next) {
-    if (Object.keys(req.query).length <= 1 && req.query['next'] === 'true') {
+    if (Object.keys(req.query).length <= 1 && req.query['queryConstant'] === 'true') {
       coverage["PagingMultipleWithQueryParameters"]++;
       res.status(200).json({ "values" : [ {"properties":{"id": 2, "name": "Product" }}]});
     }

--- a/legacy/routes/paging.js
+++ b/legacy/routes/paging.js
@@ -33,6 +33,8 @@ var paging = function(coverage) {
   coverage["PagingNextLinkNameNull"] = 0;
   coverage['PagingSingle'] = 0;
   coverage['PagingMultiple'] = 0;
+  coverage['PagingMultipleWithQueryParametersInitialFunction'] = 0;
+  coverage['PagingMultipleWithQueryParametersNextFunction'] = 0;
   coverage['PagingOdataMultiple'] = 0;
   coverage['PagingMultiplePath'] = 0;
   coverage['PagingMultipleRetryFirst'] = 0;
@@ -64,6 +66,34 @@ var paging = function(coverage) {
 
     coverage["PagingMultiple"]++;
     res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"http://localhost:" + utils.getPort() + "/paging/multiple/page/2" });
+  });
+
+  router.get('/multiple/getWithQueryParams', function(req, res, next) {
+    if (req.query['requiredQueryParameter'] == '100' && req.query['optionalQueryParameter'] == 'optional') {
+      coverage["PagingMultipleWithQueryParametersInitialFunction"]++;
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}], "nextLink":"http://localhost:" + utils.getPort() + "/paging/multiple/nextOperationWithQueryParams" });
+    }
+    else{
+        utils.send400(res, next, 'The query parameters to getWithQueryParams were not passed correctly');
+    }
+  });
+
+  router.get('/multiple/nextOperationWithQueryParams', function(req, res, next) {
+    if (Object.keys(req.query).length <= 1 && req.query['next'] === 'true') {
+      coverage["PagingMultipleWithQueryParametersNextFunction"]++;
+      res.status(200).json({ "values" : [ {"properties":{"id": 2, "name": "Product" }}]});
+    }
+    else{
+        utils.send400(res, next, 'The query parameters to getWithQueryParams were not passed correctly');
+    }
+  });
+
+  router.get('/multiple/page/:pagenumber', function(req, res, next) {
+    if (req.params.pagenumber < 10) {
+      res.status(200).json({ "values": [ {"properties":{"id" : parseInt(req.params.pagenumber), "name": "product"}} ], "nextLink": "http://localhost:" + utils.getPort() + "/paging/multiple/page/" + (++req.params.pagenumber) });
+    } else {
+      res.status(200).json({"values": [ {"properties":{"id" : parseInt(req.params.pagenumber), "name": "product"}} ]});
+    }
   });
 
   router.get('/multiple/page/:pagenumber', function(req, res, next) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.29",
+  "version": "2.10.30",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -134,15 +134,13 @@
           },
           {
             "name": "queryConstant",
-            "in": "body",
-            "description": "A constant. Will be passed as a query parameter to nextOperationWithQueryParams",
+            "in": "query",
+            "description": "A constant. Must be True and will be passed as a query parameter to nextOperationWithQueryParams",
             "required": true,
-            "schema": {
-              "type": "boolean",
-              "enum": [
-                true
-              ]
-            }
+            "type": "boolean",
+            "enum": [
+              true
+            ]
           }
 		    ],
         "responses": {
@@ -167,9 +165,12 @@
           {
             "name": "queryConstant",
             "in": "query",
-            "description": "A required boolean query parameter. Pass in True. This is a constant parameter in the initial function getWithQueryParams",
+            "description": "A constant. Must be True",
             "required": true,
-            "type": "boolean"
+            "type": "boolean",
+            "enum": [
+              true
+            ]
           }
 		    ],
         "responses": {

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -123,7 +123,7 @@
       "get": {
         "x-ms-pageable": { "nextLinkName": "nextLink", "itemName": "values", "operationName": "Paging_nextOperationWithQueryParams" },
         "operationId": "Paging_getWithQueryParams",
-        "description": "A paging operation that includes a next operation. It has different query parameters than it's next operation nextOperationWithQueryParams has. Returns a ProductResult",
+        "description": "A paging operation that includes a next operation. It has a different query parameter from it's next operation nextOperationWithQueryParams. Returns a ProductResult",
         "parameters": [
           {
             "name": "requiredQueryParameter",
@@ -133,14 +133,7 @@
             "type": "integer"
           },
           {
-            "name": "optionalQueryParameter",
-            "in": "query",
-            "description": "An optional string query parameter. Put in 'optional' to pass test",
-            "required": false,
-            "type": "string"
-          },
-          {
-            "name": "next",
+            "name": "queryConstant",
             "in": "body",
             "description": "A constant. Will be passed as a query parameter to nextOperationWithQueryParams",
             "required": true,
@@ -172,7 +165,7 @@
         "description": "Next operation for getWithQueryParams. Pass in next=True to pass test. Returns a ProductResult",
         "parameters": [
           {
-            "name": "next",
+            "name": "queryConstant",
             "in": "query",
             "description": "A required boolean query parameter. Pass in True. This is a constant parameter in the initial function getWithQueryParams",
             "required": true,

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -119,6 +119,85 @@
         }
       }
     },
+    "/paging/multiple/getWithQueryParams": {
+      "get": {
+        "x-ms-pageable": { "nextLinkName": "nextLink", "itemName": "values", "operationName": "Paging_nextOperationWithQueryParams" },
+        "operationId": "Paging_getWithQueryParams",
+        "description": "A paging operation that includes a next operation. It has different query parameters than it's next operation nextOperationWithQueryParams has. Returns a ProductResult",
+        "parameters": [
+          {
+            "name": "client-request-id",
+            "in": "header",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "requiredQueryParameter",
+            "in": "query",
+            "description": "A required integer query parameter. Put in value '100' to pass test.",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "optionalQueryParameter",
+            "in": "query",
+            "description": "An optional string query parameter. Put in 'optional' to pass test",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "next",
+            "in": "body",
+            "description": "A constant. Will be passed as a query parameter to nextOperationWithQueryParams",
+            "required": true,
+            "schema": {
+              "type": "boolean",
+              "enum": [
+                true
+              ]
+            }
+          }
+		    ],
+        "responses": {
+          "200": {
+            "description": "Initial response with ProvisioningState='Canceled'",
+            "schema": {
+              "$ref": "#/definitions/ProductResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/paging/multiple/nextOperationWithQueryParams": {
+      "get": {
+        "x-ms-pageable": { "nextLinkName": "nextLink", "itemName": "values" },
+        "operationId": "Paging_nextOperationWithQueryParams",
+        "description": "Next operation for getWithQueryParams. Pass in next=True to pass test. Returns a ProductResult",
+        "parameters": [
+          {
+            "name": "next",
+            "in": "query",
+            "description": "A required boolean query parameter. Pass in True. This is a constant parameter in the initial function getWithQueryParams",
+            "required": true,
+            "type": "boolean"
+          }
+		    ],
+        "responses": {
+          "200": {
+            "description": "Initial response with ProvisioningState='Canceled'",
+            "schema": {
+              "$ref": "#/definitions/ProductResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
     "/paging/multiple/odata": {
       "get": {
         "x-ms-pageable": { "nextLinkName": "odata.nextLink", "itemName": "values" },

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -126,12 +126,6 @@
         "description": "A paging operation that includes a next operation. It has different query parameters than it's next operation nextOperationWithQueryParams has. Returns a ProductResult",
         "parameters": [
           {
-            "name": "client-request-id",
-            "in": "header",
-            "required": false,
-            "type": "string"
-          },
-          {
             "name": "requiredQueryParameter",
             "in": "query",
             "description": "A required integer query parameter. Put in value '100' to pass test.",


### PR DESCRIPTION
Adds required coverage 'PagingMultipleWithQueryParameters'. 

To pass, you need to first pass '100' to `requiredQueryParameter`. `getWithQueryParams` has constant `queryConstant` defined to be true and that must make it's way to the testserver. The query parameter `queryConstant` (and only `queryConstant`) then needs to be passed correctly to the next operation `nextOperationWithQueryParams` to finally pass 'PagingMultipleWithQueryParameters'