### PR TITLE
added test for content type with encoding

### DIFF
--- a/legacy/routes/mediatypes.js
+++ b/legacy/routes/mediatypes.js
@@ -5,6 +5,7 @@ var utils = require('../util/utils')
 var mediatypes = function(coverage) {
     coverage['MediaTypeJson'] = 0;
     coverage['MediaTypePdf'] = 0;
+    coverage['MediaTypeWithEncoding'] = 0;
 
     router.post('/analyze', function(req, res, next) {
         let content_type = req.headers["content-type"];
@@ -26,6 +27,17 @@ var mediatypes = function(coverage) {
             utils.send400(res, next, 'Did not received what I was expecting');
         }
     });
+    router.post('/contentTypeWithEncoding', function(req, res, next) {
+        let content_type = req.headers["content-type"];
+        if (content_type === 'text/plain; encoding=UTF-8') {
+            coverage['MediaTypeWithEncoding']++;
+            res.status(200).json("Nice job sending content type with encoding");
+        }
+        else{
+            utils.send400(res, next, 'Did not receive what I was expecting');
+        }
+    });
+
 }
 
 mediatypes.prototype.router = router;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.33",
+  "version": "2.10.34",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/swagger/media_types.json
+++ b/swagger/media_types.json
@@ -38,6 +38,31 @@
 					}
 				}
 			}
+		},
+		"/mediatypes/contentTypeWithEncoding": {
+			"post": {
+				"description": "Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter",
+				"operationId": "contentTypeWithEncoding",
+				"consumes": [
+					"text/plain"
+				],
+				"produces": [
+					"application/json"
+				],
+				"parameters": [
+					{
+						"$ref": "#/parameters/Input"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Received 'text/plain; encoding=UTF-8' as contentType",
+						"schema": {
+							"type": "string"
+						}
+					}
+				}
+			}
 		}
 	},
 	"definitions": {


### PR DESCRIPTION
This adds required coverage 'MediaTypeWithEncoding'. To pass it, pass contentType 'text/plain; encoding=UTF-8' (I haven't made input value required, should this be?)