### PR TITLE
LRO: PUT 201 successful test

### DIFF
--- a/legacy/routes/lros.js
+++ b/legacy/routes/lros.js
@@ -41,6 +41,7 @@ var getPascalCase = function (inString) {
 
 var lros = function (coverage) {
   coverage['LROPutInlineComplete'] = 0;
+  coverage['LROPutInlineComplete201'] = 0;
   coverage['CustomHeaderPutAsyncSucceded'] = 0;
   coverage['CustomHeaderPostAsyncSucceded'] = 0;
   coverage['CustomHeaderPutSucceeded'] = 0;
@@ -48,6 +49,11 @@ var lros = function (coverage) {
   router.put('/put/200/succeeded', function (req, res, next) {
     coverage['LROPutInlineComplete']++;
     res.status(200).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
+  });
+
+  router.put('/put/201/succeeded', function (req, res, next) {
+    coverage['LROPutInlineComplete201']++;
+    res.status(201).type('json').end('{ "properties": { "provisioningState": "Succeeded"}, "id": "100", "name": "foo" }');
   });
 
   coverage['LROPut200InlineCompleteNoState'] = 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.36",
+  "version": "2.10.37",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/swagger/lro.json
+++ b/swagger/lro.json
@@ -53,6 +53,40 @@
         }
       }
     },
+    "/lro/put/201/succeeded": {
+      "put": {
+        "x-ms-long-running-operation": true,
+        "operationId": "LROs_put201Succeeded",
+        "description": "Long running put request, service returns a 201 to the initial request, with an entity that contains ProvisioningState=’Succeeded’.",
+        "tags": [
+          "LRO Operations"
+        ],
+        "parameters": [
+          {
+            "name": "product",
+            "description": "Product to put",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Initial response with ProvisioningState='Succeeded'",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
     "/lro/list": {
       "post": {
         "x-ms-long-running-operation": true,


### PR DESCRIPTION
See: https://github.com/Azure/autorest.csharp/issues/743

Basically, for PUT specifically, an ARM resource can succeed on the initial call, and return a 201 status code. This test is specifically for `Resources_CreateOrUpdate` in the resources RP, where this can happen.