### PR TITLE
switched summary and description in some swaggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.37",
+  "version": "2.10.38",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/swagger/body-datetime.json
+++ b/swagger/body-datetime.json
@@ -131,8 +131,8 @@
     "/datetime/max/utc7ms": {
       "put": {
         "operationId": "datetime_putUtcMaxDateTime7Digits",
-        "description": "Put max datetime value 9999-12-31T23:59:59.9999999Z",
-        "summary": "This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario",
+        "description": "This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario",
+        "summary": "Put max datetime value 9999-12-31T23:59:59.9999999Z",
         "parameters": [
           {
             "name": "datetimeBody",
@@ -202,8 +202,8 @@
     "/datetime/max/utc7ms/uppercase": {
       "get": {
         "operationId": "datetime_getUtcUppercaseMaxDateTime7Digits",
-        "description": "Get max datetime value 9999-12-31T23:59:59.9999999Z",
-        "summary": "This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario",
+        "description": "This is against the recommendation that asks for 3 digits, but allow to test what happens in that scenario",
+        "summary": "Get max datetime value 9999-12-31T23:59:59.9999999Z",
         "responses": {
           "200": {
             "description": "The max datetime value 9999-12-31T23:59:59.9999999Z",

--- a/swagger/url.json
+++ b/swagger/url.json
@@ -379,8 +379,8 @@
     "/paths/string/begin!*'();:@&=+$,end/{stringPath}": {
       "get": {
         "operationId": "paths_stringUrlNonEncoded",
-        "description": "Get 'begin!*'();:@&=+$,end",
-        "summary": "https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded",
+        "description": "https://tools.ietf.org/html/rfc3986#appendix-A 'path' accept any 'pchar' not encoded",
+        "summary": "Get 'begin!*'();:@&=+$,end",
         "tags": [
           "Path Operations"
         ],


### PR DESCRIPTION
There's certain swaggers that have the meaning of "description" and "summary" flipped, so I flipped those back