### PR TITLE
Added paging test for model whose item name has x-ms-client-name

### DIFF
--- a/legacy/routes/paging.js
+++ b/legacy/routes/paging.js
@@ -45,6 +45,7 @@ var paging = function(coverage) {
   coverage['PagingMultipleLRO'] = 0;
   coverage['PagingCustomUrlPartialNextLink'] = 0;
   coverage["PagingCustomUrlPartialOperationNextLink"] = 0;
+  coverage["PagingReturnModelWithXMSClientName"] = 0;
 
   router.get('/noitemname', function(req, res, next) {
     coverage["PagingNoItemName"]++;
@@ -198,6 +199,11 @@ var paging = function(coverage) {
     else {
       res.status(200).json({"values": [ {"properties":{"id" : parseInt(req.query.page), "name": "product"}} ]});
     }
+  });
+
+  router.get('/itemNameWithXMSClientName', function(req, res, next) {
+    coverage["PagingReturnModelWithXMSClientName"]++;
+    res.status(200).json({ "values" : [ {"properties":{"id": 1, "name": "Product" }}]});
   });
 
   /*** PAGEABLE LROs ***/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.39",
+  "version": "2.10.40",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -600,6 +600,24 @@
           }
         }
       }
+    },
+    "/paging/itemNameWithXMSClientName": {
+      "get": {
+        "x-ms-pageable": { "nextLinkName": "nextLink", "itemName": "values" },
+        "operationId": "Paging_getPagingModelWithItemNameWithXMSClientName",
+        "description": "A paging operation that returns a paging model whose item name is is overriden by x-ms-client-name 'indexes'.",
+        "responses": {
+          "200": {
+            "description": "Returns a paging model whose item names are called 'indexes', not 'value'",
+            "schema": {
+              "$ref": "#/definitions/ProductResultValueWithXMSClientName"
+            }
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -608,6 +626,21 @@
       "properties": {
         "value": {
           "type": "array",
+          "items": {
+            "$ref": "#/definitions/Product"
+          }
+        },
+        "nextLink": {
+          "type": "string"
+        }
+      }
+    },
+    "ProductResultValueWithXMSClientName": {
+      "type":  "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "x-ms-client-name": "Indexes",
           "items": {
             "$ref": "#/definitions/Product"
           }


### PR DESCRIPTION
fixes #182 

Added require coverage 'PagingReturnModelWithXMSClientName'. 

The test involves generating an operation, which returns a paging model whose item name has an x-ms-client-name.