### PR TITLE
Fix formatting of string_getBase64Encoded response

### DIFF
--- a/swagger/body-string.json
+++ b/swagger/body-string.json
@@ -413,7 +413,7 @@
             "description": "The base64 encoded string value",
             "schema": {
               "type": "string",
-              "format": "base64url"
+              "format": "byte"
             }
           },
           "default": {


### PR DESCRIPTION
The description of the operation states base-64 encoded however the
format was incorrectly set to base-64 URL encoded.  In addition, the
route sends a base-64 encoded value.