### PR TITLE
bump version for query array test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.47",
+  "version": "2.10.48",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
Ended up not bumping the package version in my query array test PR since someone merged a PR before me and I didn't bump the package version again from that. My apologies