### PR TITLE
Add a body-formdata operation that accepts an array of files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.55",
+  "version": "2.10.56",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/swagger/body-formdata.json
+++ b/swagger/body-formdata.json
@@ -98,6 +98,49 @@
           }
         }
       }
+    },
+    "/formdata/stream/uploadfiles": {
+      "post": {
+        "operationId": "formdata_UploadFiles",
+        "consumes": [
+          "multipart/form-data",
+          "application/octet-stream"
+        ],
+        "produces": [
+          "application/octet-stream",
+          "application/json"
+        ],
+        "description": "Upload multiple files",
+        "tags": [
+          "Formdata"
+        ],
+        "parameters": [
+          {
+            "name": "fileContent",
+            "description": "Files to upload.",
+            "required": true,
+            "type": "array",
+            "in": "formData",
+            "items": {
+              "type": "file"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Serialized file stream",
+            "schema": {
+              "type": "file"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
This adds a new operation called 'uploadfiles' to the `body-formdata.json` spec which exercises the case where a `formData` parameter has an array of `file` items to enable uploading multiple files in one API call.  I haven't added the backend support for this yet, would appreciate some pointers on that!