### PR TITLE
Fix the inheritance of xms error codes json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.60",
+  "version": "2.10.61",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/swagger/xms-error-responses.json
+++ b/swagger/xms-error-responses.json
@@ -191,6 +191,11 @@
    }
   },
   "PetActionError": {
+    "allOf": [
+     {
+        "$ref": "#/definitions/PetAction"
+     }
+    ],
    "properties": {
     "errorType": {
      "type": "string"


### PR DESCRIPTION
This PR is related to Issue https://github.com/Azure/autorest.typescript/issues/749. 

Currently, the inheritance is not defined correctly in the JSON File. 

1. Take a look [here](https://github.com/Azure/autorest.testserver/blob/ee473a350ebd680a728acda7d3bbd4334e9826a0/legacy/routes/errorStatusCodes.js#L59). This returns the object `hungryScooby`. 

2. The definition of `hungryScooby` is:

```
{
    "actionResponse":"howl",
    "errorType":"PetHungryOrThirstyError",
    "errorMessage":"scooby is low",
    "reason":"need more everything",
    "hungryOrThirsty":"hungry and thirsty"
}
```

The `actionResponse` property is defined only in PetAction. Else, TS will start complaining.

This PR will fix it. 

@joheredi Please review and approve.
 