### PR TITLE
add test for error deserialization in op with param name 'models'

### DIFF
--- a/legacy/app.js
+++ b/legacy/app.js
@@ -504,7 +504,8 @@ var coverage = {
   "intError":0,
   "stringError":0,
   "animalNotFoundError":0,
-  "linkNotFoundError":0
+  "linkNotFoundError":0,
+  "sendErrorWithParamNameModels": 0
 };
 
 // view engine setup

--- a/legacy/app.js
+++ b/legacy/app.js
@@ -505,7 +505,6 @@ var coverage = {
   "stringError":0,
   "animalNotFoundError":0,
   "linkNotFoundError":0,
-  "sendErrorWithParamNameModels": 0
 };
 
 // view engine setup
@@ -556,7 +555,7 @@ app.use('/parameterGrouping', new parameterGrouping(azurecoverage).router);
 app.use('/validation', new validation(coverage).router);
 app.use('/customUri', new customUri(coverage).router);
 app.use('/extensibleEnums', new extensibleEnums(coverage).router);
-app.use('/errorStatusCodes', new errorStatusCodes(coverage).router);
+app.use('/errorStatusCodes', new errorStatusCodes(coverage, optionalCoverage).router);
 app.use('/additionalProperties', new additionalProperties(coverage).router);
 app.use('/mediatypes', new mediatypes(coverage).router);
 app.use('/xml', new xml(coverage).router);

--- a/legacy/routes/errorStatusCodes.js
+++ b/legacy/routes/errorStatusCodes.js
@@ -95,6 +95,16 @@ var pathitem = function(coverage) {
             res.status(402).end("That's all folks!!");
         }
     });
+
+    router.post('/Pets/hasModelsParam', function(req, res, next) {
+        models_param = req.query['models']
+        if (models_param == 'value1') {
+            res.status(500).json(sadCasper);
+            coverage['sendErrorWithParamNameModels']++;
+        } else {
+            utils.send400(res, next, "The value of input param models is " + models_param + " and not the client default value of 'value1'");
+        }
+    });
 }
 
 pathitem.prototype.router = router;

--- a/legacy/routes/errorStatusCodes.js
+++ b/legacy/routes/errorStatusCodes.js
@@ -44,7 +44,8 @@ var animalNotFoundError = {
 };
 
 
-var pathitem = function(coverage) {
+var pathitem = function(coverage, optionalCoverage) {
+    optionalCoverage['sendErrorWithParamNameModels'] = 0;
     router.post('/Pets/doSomething/:whatAction', function(req, res, next) {
         var whatAction = req.params.whatAction;
         console.log('Inside action: "' + whatAction +'"\n');
@@ -100,7 +101,7 @@ var pathitem = function(coverage) {
         models_param = req.query['models']
         if (models_param == 'value1') {
             res.status(500).json(sadCasper);
-            coverage['sendErrorWithParamNameModels']++;
+            optionalCoverage['sendErrorWithParamNameModels']++;
         } else {
             utils.send400(res, next, "The value of input param models is " + models_param + " and not the client default value of 'value1'");
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.62",
+  "version": "2.10.63",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.63",
+  "version": "2.10.64",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",

--- a/swagger/xms-error-responses.json
+++ b/swagger/xms-error-responses.json
@@ -112,7 +112,7 @@
         "in": "query",
         "type": "string",
         "x-ms-client-default": "value1",
-        "description": "Make sure model deserialization doesn't conflic with this param name, which has input name 'models'. Use client default value in call"
+        "description": "Make sure model deserialization doesn't conflict with this param name, which has input name 'models'. Use client default value in call"
        }
       ],
       "responses": {

--- a/swagger/xms-error-responses.json
+++ b/swagger/xms-error-responses.json
@@ -9,6 +9,12 @@
  "schemes": [
   "http"
  ],
+ "produces": [
+   "application/json"
+],
+"consumes": [
+   "application/json"
+],
  "paths": {
   "/errorStatusCodes/Pets/{petId}/GetPet": {
    "get": {
@@ -57,13 +63,7 @@
      "default": {
       "description": "default stuff"
      }
-    },
-    "produces": [
-     "application/json"
-    ],
-    "consumes": [
-     "application/json"
-    ]
+    }
    }
   },
   "/errorStatusCodes/Pets/doSomething/{whatAction}": {
@@ -99,14 +99,41 @@
        "$ref": "#/definitions/PetActionError"
       }
      }
-    },
-    "produces": [
-     "application/json"
-    ],
-    "consumes": [
-     "application/json"
-    ]
+    }
    }
+  },
+  "/errorStatusCodes/Pets/hasModelsParam": {
+   "post": {
+      "operationId": "Pet_HasModelsParam",
+      "description": "Ensure you can correctly deserialize the returned PetActionError and deserialization doesn't conflict with the input param name 'models'",
+      "parameters": [
+       {
+        "name": "models",
+        "in": "query",
+        "type": "string",
+        "x-ms-client-default": "value1",
+        "description": "Make sure model deserialization doesn't conflic with this param name, which has input name 'models'. Use client default value in call"
+       }
+      ],
+      "responses": {
+       "200": {
+        "description": "OK. We will be returning an error though"
+       },
+       "500": {
+         "description": "Will return error. Make sure the error can be correctly deserialized",
+         "schema": {
+          "$ref": "#/definitions/PetActionError"
+         },
+         "x-ms-error-response": true
+        },
+       "default": {
+        "description": "Default",
+        "schema": {
+         "$ref": "#/definitions/PetActionError"
+        }
+       }
+      }
+     }
   }
  },
  "definitions": {


### PR DESCRIPTION
Python ran into an issue for (error) model deserialization when our operation had an input parameter named `models`. 
(python [ex](https://github.com/Azure/azure-sdk-for-python/blob/master/sdk/digitaltwins/azure-digitaltwins-core/azure/digitaltwins/core/_generated/operations/_digital_twin_models_operations.py#L121)). Adding test to make sure other languages don't run into this conflict. Making this optional coverage, since right now it seems p specific to how python deserializes models. Other languages shouldn't have a problem passing the test though