### PR TITLE
Pass through program exit code when using start-autorest-express

### DIFF
--- a/.scripts/start-autorest-express.js
+++ b/.scripts/start-autorest-express.js
@@ -17,6 +17,10 @@ function prepend( color,pText ,text) {
 //  (b) run the given command line.
 // when the (b) completes, terminate (a)
 
+// This variable stores the exit code of the program that gets launched by
+// this script so that it can be passed through for use in CI reporting, etc
+let wrappedExitCode = 0;
+
 async function main() {
 
   const cmdArgs = [];
@@ -92,7 +96,7 @@ async function main() {
   verbose('Express is ready.')
 
   if (!interactive) {
-    await execute(command, cmdArgs, {
+    const result = await execute(command, cmdArgs, {
       onCreate: (proc) => {
         verbose(`Started command: '${command} ${cmdArgs.join(' ')}'`);
         cmdProc = proc;
@@ -109,6 +113,9 @@ async function main() {
     });
     running = false;
     verbose('Command completed.');
+
+    // Store the exit code so that it can be returned when this process exits
+    wrappedExitCode = result.error;
   } else {
     await queryUser('\n\nPress enter to stop testserver\n');
   }
@@ -139,6 +146,7 @@ async function main() {
 async function start() {
   try {
     await main();
+    process.exit(wrappedExitCode);
   } catch (e) {
     console.error(e);
     process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "2.10.65",
+  "version": "2.10.66",
   "main": "./legacy/startup/www.js",
   "bin": {
     "start-autorest-express": "./.scripts/start-autorest-express.js",


### PR DESCRIPTION
This change updates the `start-autorest-express` script so that the exit code of the program it wraps will be used as this script's own exit code when it exits.  This fixes an issue that was causing the AutoRest Swift repo's CI to report success even though there were errors while running its tests.