### PR TITLE
add test for error deserialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/src/test-routes/incorrect-error-response.ts
+++ b/src/test-routes/incorrect-error-response.ts
@@ -1,13 +1,12 @@
-
 import { app, json } from "../api";
 app.category("vanilla", () => {
-    app.get("/incorrectError", "verifyIncorrectErrorParsing", (req) => {
-        return {
-            status: 444,
-            body: {
-                contentType: "text/html",
-                rawContent: "foobar"
-            }
-          };
-    });
+  app.get("/incorrectError", "verifyIncorrectErrorParsing", (req) => {
+    return {
+      status: 444,
+      body: {
+        contentType: "text/html",
+        rawContent: "foobar",
+      }
+    };
+  });
 });

--- a/src/test-routes/incorrect-error-response.ts
+++ b/src/test-routes/incorrect-error-response.ts
@@ -6,7 +6,7 @@ app.category("vanilla", () => {
       body: {
         contentType: "text/html",
         rawContent: "foobar",
-      }
+      },
     };
   });
 });

--- a/src/test-routes/incorrect-error-response.ts
+++ b/src/test-routes/incorrect-error-response.ts
@@ -1,0 +1,13 @@
+
+import { app, json } from "../api";
+app.category("vanilla", () => {
+    app.get("/incorrectError", "verifyIncorrectErrorParsing", (req) => {
+        return {
+            status: 444,
+            body: {
+                contentType: "text/html",
+                rawContent: "foobar"
+            }
+          };
+    });
+});

--- a/swagger/incorrect-error-response.json
+++ b/swagger/incorrect-error-response.json
@@ -1,0 +1,51 @@
+{
+    "swagger": "2.0",
+    "info": {
+      "title": "Incorrect Returned Error Model",
+      "description": "Test to see when throwing an HttpResponseError whether we swallow error model deserialization errors",
+      "version": "1.0.0"
+    },
+    "host": "localhost:3000",
+    "schemes": [
+      "http"
+    ],
+    "produces": [
+      "text/html"
+    ],
+    "consumes": [
+      "application/json"
+    ],
+    "paths": {
+      "/incorrectError": {
+        "get": {
+          "operationId": "getIncorrectErrorFromServer",
+          "description": "Get an error response from the server that is not as described in our Error object. Want to swallow the deserialization error and still return an HttpResponseError to the users.",
+          "responses": {
+            "200": {
+              "description": "We will only return an error, so should expect a call to this service to fail."
+            },
+            "default": {
+              "description": "Error response from server. Will not abide by the defined Error model. Want to swallow the deserialization error and still return the overall HttpResponseError to users.",
+              "schema": {
+                "$ref": "#/definitions/Error"
+              }
+            }
+          }
+        }
+      }
+    },
+    "definitions": {
+      "Error": {
+        "type":  "object",
+        "properties": {
+          "status": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }


### PR DESCRIPTION
Python has an [issue](https://github.com/Azure/autorest.python/issues/791) where, in the case of failed error model deserialization, we still want to return an `HttpResponseError` to users, not a deserialization error. This is a test that throws an incorrect error model, that should result in a deserialization error. Ideally, your autorest code should throw an `HttpResponseError` instead of a `DeserializationError`