### PR TITLE
Feature: Add a new command to validate coverage of openapi specs

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -34,3 +34,4 @@ jobs:
           npm link
           autorest-testserver validate-spec-coverage
         displayName: Validate OpenAPI specs mock API coverage
+        continueOnError: true

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -1,6 +1,6 @@
 name: Autorest Testserver CI
 trigger: none
-pr: 
+pr:
   - master
 
 pool:
@@ -29,3 +29,8 @@ jobs:
 
       - script: npm run lint
         displayName: Lint
+
+      - script: |
+          npm link
+          autorest-testserver validate-spec-coverage
+        displayName: Validate OpenAPI specs mock API coverage

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -8,7 +8,7 @@ import { coverageService } from "../services";
 import { findFilesFromPattern } from "../utils";
 import { ApiMockAppConfig } from "./config";
 
-const ROUTE_FOLDER = path.join(__dirname, "../test-routes");
+export const ROUTE_FOLDER = path.join(__dirname, "../test-routes");
 
 export class ApiMockApp {
   private server: MockApiServer;
@@ -30,7 +30,7 @@ export class ApiMockApp {
   }
 }
 
-const requireMockRoutes = async (routesFolder: string) => {
+export const requireMockRoutes = async (routesFolder: string): Promise<void> => {
   const files = await findFilesFromPattern(path.join(routesFolder, "/**/*.js"));
   logger.debug("Detected routes:", files);
   for (const file of files) {

--- a/src/cli/args-parser.ts
+++ b/src/cli/args-parser.ts
@@ -10,6 +10,7 @@ export const parseArgs = (argv: string[]): CliConfig => {
     .strict()
     .command("$0", "Run the autorest test server.")
     .command("stop", "Stop the autorest test server running at the provided port.")
+    .command("validate-spec-coverage", "Validate there is a mock api for all the path defined in the specs")
     .option("verbose", {
       alias: "v",
       type: "boolean",

--- a/src/cli/cli-config.ts
+++ b/src/cli/cli-config.ts
@@ -17,5 +17,5 @@ export interface CliConfig {
   /**
    * Command to use
    */
-  command: "run" | "stop";
+  command: "run" | "stop" | "validate-spec-coverage";
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -6,7 +6,7 @@ require("source-map-support").install();
 import { hideBin } from "yargs/helpers";
 import { logger, setLoggingLevelFromConfig } from "../logger";
 import { parseArgs } from "./args-parser";
-import { stopCommand, runCommand } from "./commands";
+import { stopCommand, runCommand, validateSpecCoverageCommand } from "./commands";
 
 const run = async () => {
   const cliConfig = parseArgs(hideBin(process.argv));
@@ -17,6 +17,9 @@ const run = async () => {
       break;
     case "stop":
       await stopCommand(cliConfig);
+      break;
+    case "validate-spec-coverage":
+      await validateSpecCoverageCommand(cliConfig);
       break;
   }
 };

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,2 +1,3 @@
 export * from "./run-command";
 export * from "./stop-command";
+export * from "./validate-spec-coverage-command";

--- a/src/cli/commands/validate-spec-coverage-command.ts
+++ b/src/cli/commands/validate-spec-coverage-command.ts
@@ -1,7 +1,6 @@
 import { join } from "path";
-import { firstCharLowerCase } from "xml2js/lib/processors";
 import { app, HttpMethod } from "../../api";
-import { ApiMockApp, requireMockRoutes, ROUTE_FOLDER } from "../../app";
+import { requireMockRoutes, ROUTE_FOLDER } from "../../app";
 import { ProjectRoot } from "../../constants";
 import { logger } from "../../logger";
 import { getPathsFromSpecs, SpecPath } from "../../services";

--- a/src/cli/commands/validate-spec-coverage-command.ts
+++ b/src/cli/commands/validate-spec-coverage-command.ts
@@ -1,0 +1,85 @@
+import { join } from "path";
+import { firstCharLowerCase } from "xml2js/lib/processors";
+import { app, HttpMethod } from "../../api";
+import { ApiMockApp, requireMockRoutes, ROUTE_FOLDER } from "../../app";
+import { ProjectRoot } from "../../constants";
+import { logger } from "../../logger";
+import { getPathsFromSpecs, SpecPath } from "../../services";
+import { findFilesFromPattern } from "../../utils";
+import { CliConfig } from "../cli-config";
+
+interface Layer {
+  route: { path: string; methods: Record<HttpMethod, boolean> };
+  regexp: RegExp;
+}
+
+export const validateSpecCoverageCommand = async (cliConfig: CliConfig): Promise<void> => {
+  const files = await findFilesFromPattern(join(ProjectRoot, "swagger/*.json"));
+  logger.info(`Validating spec coverage, found ${files.length} specs.`);
+  const paths = await getPathsFromSpecs(files);
+  logger.info(`Found ${paths.length} paths.`);
+
+  await requireMockRoutes(ROUTE_FOLDER);
+  const apiRouter = app;
+
+  const registeredPaths: Layer[] = apiRouter.router.stack.filter((x) => x.route);
+  logger.info(`Found ${registeredPaths.length} mock paths.`);
+
+  const errors = findSpecCoverageErrors(paths, registeredPaths);
+  if (errors.length) {
+    for (const error of errors) {
+      logger.warn(`Route ${error.path.path} is missing a mocked API for methods: ${error.methods.join(",")}`);
+    }
+    logger.error(`Validate spec coverage completed with ${errors.length} errors.`);
+    process.exit(-1);
+  } else {
+    process.exit(0);
+  }
+};
+
+interface SpecCoverageError {
+  /**
+   * Path missing some or all methods implemented.
+   */
+  path: SpecPath;
+
+  /**
+   * List of non implemented methods.
+   */
+  methods: HttpMethod[];
+}
+
+const findSpecCoverageErrors = (paths: SpecPath[], registeredPaths: Layer[]): SpecCoverageError[] => {
+  const errors: SpecCoverageError[] = [];
+  for (const path of paths) {
+    const missingMethods = validateRouteDefined(path, registeredPaths);
+    if (missingMethods.length > 0) {
+      errors.push({ path: path, methods: missingMethods });
+    } else {
+      logger.debug(`Route ${path.path} has a mocked API.`);
+    }
+  }
+  return errors;
+};
+
+/**
+ * Validat the given path is defined in the mock api.
+ * @param path Path to validate
+ * @param registeredPaths List of all registered mock apis.
+ * @returns list of methods that are not implemented for the given path.
+ */
+const validateRouteDefined = (path: SpecPath, registeredPaths: Layer[]): HttpMethod[] => {
+  const methodFound: Partial<Record<HttpMethod, boolean>> = {};
+
+  for (const registeredPath of registeredPaths) {
+    if (registeredPath.regexp.test(path.path)) {
+      for (const [method, defined] of Object.entries(registeredPath.route.methods)) {
+        if (defined) {
+          methodFound[method as HttpMethod] = true;
+        }
+      }
+    }
+  }
+
+  return path.methods.filter((x) => !methodFound[x]);
+};

--- a/src/legacy/legacy.ts
+++ b/src/legacy/legacy.ts
@@ -3,6 +3,7 @@
 /**
  * This file handles loading the legacy test server routes.
  */
+import { Router } from "express";
 import { Category } from "../api";
 import { ProjectRoot } from "../constants";
 import { MockApiServer } from "../server";
@@ -68,7 +69,7 @@ const proxyCoverage = (category: Category, coverage: CoverageMap) => {
   });
 };
 
-export const registerLegacyRoutes = (app: MockApiServer): void => {
+export const registerLegacyRoutes = (app: MockApiServer | Router): void => {
   const azurecoverage = proxyCoverage("azure", {});
   const optionalCoverage = proxyCoverage("optional", {
     getDecimalInvalid: 0,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,1 +1,2 @@
 export * from "./coverage-service";
+export * from "./spec-coverage-service";

--- a/src/services/spec-coverage-service.ts
+++ b/src/services/spec-coverage-service.ts
@@ -1,0 +1,54 @@
+import fs from "fs";
+import { HttpMethod } from "../api";
+import { logger } from "../logger";
+
+export interface SpecPath {
+  /**
+   * Path to implement.
+   */
+  path: string;
+  /**
+   * List of HTTP methods to implement.
+   */
+  methods: HttpMethod[];
+}
+
+export const getPathsFromSpecs = async (specPaths: string[]): Promise<SpecPath[]> => {
+  let paths: SpecPath[] = [];
+  for (const specPath of specPaths) {
+    paths = paths.concat(await getPathsFromSpec(specPath));
+  }
+  return paths;
+};
+
+const getPathsFromSpec = async (specPath: string): Promise<SpecPath[]> => {
+  logger.debug(`Parsing spec ${specPath}`);
+  const json = await parseSpec(specPath);
+  return json.paths && typeof json.paths === "object" ? parseOpenAPIPath(json.paths as Record<string, unknown>) : [];
+};
+
+const parseOpenAPIPath = (paths: Record<string, unknown>): SpecPath[] => {
+  return Object.entries(paths)
+    .map(([path, content]) => {
+      return {
+        path,
+        methods: content && typeof content === "object" ? (Object.keys(content) as HttpMethod[]) : [],
+      };
+    })
+    .filter((x) => x.methods.length > 0);
+};
+
+const parseSpec = async (specPath: string): Promise<Record<string, unknown>> => {
+  const content = await fs.promises.readFile(specPath);
+  try {
+    const json = JSON.parse(content.toString().replace(/^\uFEFF/, ""));
+
+    if (typeof json !== "object") {
+      throw new Error(`Spec ${specPath} is not valid, should be an json object.`);
+    }
+
+    return json;
+  } catch (e) {
+    throw new Error(`Spec ${specPath} is not valid json, ${e}`);
+  }
+};


### PR DESCRIPTION
New comand to validate missing apis
```bash
autorest-testserver validate-spec-coverage
```

Current `--help`:

```bash
PS C:\dev\azsdk\autorest.megarepo\testserver> autorest-testserver --help
cli.js

Run the autorest test server.

Commands:
  cli.js                         Run the autorest test server.         [default]
  cli.js stop                    Stop the autorest test server running at the
                                 provided port.
  cli.js validate-spec-coverage  Validate there is a mock api for all the path
                                 defined in the specs

Options:
      --version            Show version number                         [boolean]
      --help               Show help                                   [boolean]
  -v, --verbose            Run with verbose logging level.             [boolean]
      --debug              Run with debug logging level.               [boolean]
      --level              Run with given logging level.                [string]
  -p, --port               Port where to host the server[number] [default: 3000]
      --coverageDirectory  Path of the directory where the coverage reports
                           should be saved.
        [string] [default: "C:\dev\azsdk\autorest.megarepo\testserver\coverage"]
```

Result example 
![image](https://user-images.githubusercontent.com/1031227/105549700-f0940300-5cb5-11eb-8973-55f8c6a8cc3e.png)

Will be set to allow failure in the CI for now.

Thinking maybe of having a diff coverage functionality. Coverage needs to improve (at least not decrease) or CI won't merge. This means that it should at least prevent newly added swagger specs from being added without mock apis.