### PR TITLE
Scope request validation

### DIFF
--- a/docs/writing-mock-apis.md
+++ b/docs/writing-mock-apis.md
@@ -22,7 +22,7 @@ app.category("vanilla", () => {
   });
 
   app.post("/test", "PostMyTest", (req) => {
-    req.bodyEquals({ foo: "123", bar: "456" });
+    req.expect.bodyEquals({ foo: "123", bar: "456" });
     return {
       status: 200,
       body: json({
@@ -79,9 +79,11 @@ return {
 
 ## How to validate the request:
 
+All built-in validation tools can be accessed using `req.expect.`
+
 ### Validate the body
 
-- With `req.bodyEquals`
+- With `req.expect.bodyEquals`
 
 This will do a deep equals of the body to make sure it match.
 
@@ -91,7 +93,7 @@ app.post("/example", "Example", (req) => {
 });
 ```
 
-- With `req.rawBodyEquals`
+- With `req.expect.rawBodyEquals`
 
 This will compare the raw body sent.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.0.15",
+  "version": "3.0.16",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
 export * from "./response-content-utils";
+export * from "./request-expectation";
 export * from "./mock-api-router";
 export * from "./validation-error";
 import { MockApiRouter } from "./mock-api-router";

--- a/src/api/mock-request.ts
+++ b/src/api/mock-request.ts
@@ -1,16 +1,12 @@
 import { RequestExt } from "../server";
 import { getRequestBaseUrl } from "../utils";
-import {
-  validateBodyEquals,
-  validateRawBodyEquals,
-  validateXMLBodyEquals,
-  validateBodyEmpty,
-  validateBodyNotEmpty,
-} from "./request-validations";
+import { RequestExpectation } from "./request-expectation";
 
 export const BODY_NOT_EQUAL_ERROR_MESSAGE = "Body provided doesn't match expected body.";
 
 export class MockRequest {
+  public readonly expect: RequestExpectation;
+
   public readonly baseUrl: string;
   public readonly headers: { [key: string]: string };
   public readonly query: { [key: string]: string };
@@ -20,52 +16,10 @@ export class MockRequest {
 
   public constructor(public originalRequest: RequestExt) {
     this.baseUrl = getRequestBaseUrl(originalRequest);
+    this.expect = new RequestExpectation(originalRequest);
     this.headers = originalRequest.headers as { [key: string]: string };
     this.query = originalRequest.query as { [key: string]: string };
     this.params = originalRequest.params as { [key: string]: string };
     this.body = originalRequest.body;
-  }
-
-  /**
-   * Expect the raw body of the request to match the given string.
-   * @param rawBody Raw request body.
-   * @throws {ValidationError} if there is an error.
-   */
-  public rawBodyEquals(expectedRawBody: string | undefined): void {
-    validateRawBodyEquals(this.originalRequest, expectedRawBody);
-  }
-
-  /**
-   * Expect the body of the request to match the given object.
-   * @param rawBody Raw request body.
-   * @throws {ValidationError} if there is an error.
-   */
-  public bodyEquals(expectedRawBody: unknown | undefined): void {
-    validateBodyEquals(this.originalRequest, expectedRawBody);
-  }
-
-  /**
-   * Expect the body of the request to be empty.
-   * @throws {ValidationError} if there is an error.
-   */
-  public bodyEmpty(): void {
-    validateBodyEmpty(this.originalRequest);
-  }
-
-  /**
-   * Expect the body of the request to be not empty.
-   * @throws {ValidationError} if there is an error.
-   */
-  public bodyNotEmpty(): void {
-    validateBodyNotEmpty(this.originalRequest);
-  }
-
-  /**
-   * Expect the body of the request matches the XML body you expect
-   * @param expectedRawBody Raw request XML body expressed in a string.
-   * @throws {ValidationError} if there is an error.
-   */
-  public async xmlBodyEquals(expectedRawBody: string): Promise<void> {
-    await validateXMLBodyEquals(this.originalRequest, expectedRawBody);
   }
 }

--- a/src/api/request-expectation.ts
+++ b/src/api/request-expectation.ts
@@ -1,0 +1,57 @@
+import { RequestExt } from "../server";
+import {
+  validateRawBodyEquals,
+  validateBodyEquals,
+  validateBodyEmpty,
+  validateBodyNotEmpty,
+  validateXMLBodyEquals,
+} from "./request-validations";
+
+/**
+ * Class containing all the expectations that can be run on the request.
+ */
+export class RequestExpectation {
+  public constructor(private originalRequest: RequestExt) {}
+  /**
+   * Expect the raw body of the request to match the given string.
+   * @param rawBody Raw request body.
+   * @throws {ValidationError} if there is an error.
+   */
+  public rawBodyEquals(expectedRawBody: string | undefined): void {
+    validateRawBodyEquals(this.originalRequest, expectedRawBody);
+  }
+
+  /**
+   * Expect the body of the request to match the given object.
+   * @param rawBody Raw request body.
+   * @throws {ValidationError} if there is an error.
+   */
+  public bodyEquals(expectedRawBody: unknown | undefined): void {
+    validateBodyEquals(this.originalRequest, expectedRawBody);
+  }
+
+  /**
+   * Expect the body of the request to be empty.
+   * @throws {ValidationError} if there is an error.
+   */
+  public bodyEmpty(): void {
+    validateBodyEmpty(this.originalRequest);
+  }
+
+  /**
+   * Expect the body of the request to be not empty.
+   * @throws {ValidationError} if there is an error.
+   */
+  public bodyNotEmpty(): void {
+    validateBodyNotEmpty(this.originalRequest);
+  }
+
+  /**
+   * Expect the body of the request matches the XML body you expect
+   * @param expectedRawBody Raw request XML body expressed in a string.
+   * @throws {ValidationError} if there is an error.
+   */
+  public async xmlBodyEquals(expectedRawBody: string): Promise<void> {
+    await validateXMLBodyEquals(this.originalRequest, expectedRawBody);
+  }
+}

--- a/src/test-routes/lro/test.ts
+++ b/src/test-routes/lro/test.ts
@@ -13,7 +13,7 @@ app.category("example" as any, () => {
   });
 
   app.post("/test", "PostMyTest", (req) => {
-    req.bodyEquals({ foo: "123", bar: "456" });
+    req.expect.bodyEquals({ foo: "123", bar: "456" });
     return {
       status: 200,
       body: json({

--- a/src/test-routes/required-optional-params/binary-body-required-optional.ts
+++ b/src/test-routes/required-optional-params/binary-body-required-optional.ts
@@ -10,7 +10,7 @@ app.category("vanilla", () => {
   });
 
   app.put("/reqopt/explicit/required/binary-body", "ExplicitRequiredBinaryBody", async (req) => {
-    req.bodyNotEmpty();
+    req.expect.bodyNotEmpty();
     return { status: 200 };
   });
 });

--- a/src/test-routes/required-optional-params/body-required-optional.ts
+++ b/src/test-routes/required-optional-params/body-required-optional.ts
@@ -2,7 +2,7 @@ import { app, ValidationError } from "../../api";
 
 app.category("vanilla", () => {
   app.put("/reqopt/implicit/optional/body", "OptionalImplicitBody", async (req) => {
-    req.bodyEmpty();
+    req.expect.bodyEmpty();
     return { status: 200 };
   });
 });

--- a/src/test-routes/required-optional-params/general-require-optional.ts
+++ b/src/test-routes/required-optional-params/general-require-optional.ts
@@ -16,7 +16,7 @@ app.category("vanilla", () => {
     const covered = `Optional${toPascalCase(type)}${toPascalCase(scenario)}`;
 
     if (req.params.scenario === "parameter") {
-      req.bodyEmpty();
+      req.expect.bodyEmpty();
       coverageService.track("vanilla", covered);
       return { status: 200 };
     } else if (req.params.scenario === "property") {

--- a/src/test-routes/string.ts
+++ b/src/test-routes/string.ts
@@ -11,7 +11,7 @@ app.category("vanilla", () => {
     };
   });
   app.put("/string/null", "putStringNull", (req) => {
-    req.rawBodyEquals(undefined);
+    req.expect.rawBodyEquals(undefined);
     return { status: 200 };
   });
 
@@ -26,7 +26,7 @@ app.category("vanilla", () => {
   });
 
   app.put("/string/empty", "putStringEmpty", (req) => {
-    req.rawBodyEquals(`""`);
+    req.expect.rawBodyEquals(`""`);
     return { status: 200 };
   });
 
@@ -47,7 +47,7 @@ app.category("vanilla", () => {
   });
 
   app.put("/string/whitespace", "putStringWithLeadingAndTrailingWhitespace", (req) => {
-    req.rawBodyEquals('"    Now is the time for all good men to come to the aid of their country    "');
+    req.expect.rawBodyEquals('"    Now is the time for all good men to come to the aid of their country    "');
     return { status: 200 };
   });
 
@@ -62,7 +62,7 @@ app.category("vanilla", () => {
   });
 
   app.put("/string/base64UrlEncoding", "putStringBase64UrlEncoded", (req) => {
-    req.rawBodyEquals('"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw"');
+    req.expect.rawBodyEquals('"YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw"');
     return { status: 200 };
   });
 
@@ -94,7 +94,8 @@ app.category("vanilla", () => {
   });
 
   app.put("/string/mbcs", "putStringMultiByteCharacters", (req) => {
-    req.bodyEquals(MULTIBYTE_BUFFER_BODY);
+    req.expect.bodyEquals(MULTIBYTE_BUFFER_BODY);
+    req.expect.bodyEquals(MULTIBYTE_BUFFER_BODY);
     return { status: 200 };
   });
 
@@ -109,7 +110,7 @@ app.category("vanilla", () => {
   });
 
   app.put("/string/enum/notExpandable", "putEnumNotExpandable", (req) => {
-    req.rawBodyEquals('"red color"');
+    req.expect.rawBodyEquals('"red color"');
     return { status: 200 };
   });
 
@@ -124,7 +125,7 @@ app.category("vanilla", () => {
   });
 
   app.put("/string/enum/Referenced", "putEnumReferenced", (req) => {
-    req.rawBodyEquals('"red color"');
+    req.expect.rawBodyEquals('"red color"');
     return { status: 200 };
   });
 
@@ -136,7 +137,7 @@ app.category("vanilla", () => {
   });
 
   app.put("/string/enum/ReferencedConstant", "putEnumReferencedConstant", (req) => {
-    req.bodyEquals({ ColorConstant: "green-color" });
+    req.expect.bodyEquals({ ColorConstant: "green-color" });
     return { status: 200 };
   });
 });

--- a/src/test-routes/xml-service.ts
+++ b/src/test-routes/xml-service.ts
@@ -12,7 +12,7 @@ app.category("vanilla", () => {
   });
 
   app.put("/xml/bytes", "XmlPutBytes", async (req) => {
-    await req.xmlBodyEquals("<ModelWithByteProperty><Bytes>SGVsbG8gd29ybGQ=</Bytes></ModelWithByteProperty>");
+    await req.expect.xmlBodyEquals("<ModelWithByteProperty><Bytes>SGVsbG8gd29ybGQ=</Bytes></ModelWithByteProperty>");
     return { status: 201 };
   });
 
@@ -27,7 +27,7 @@ app.category("vanilla", () => {
   });
 
   app.put("/xml/url", "XmlPutUrl", async (req) => {
-    await req.xmlBodyEquals(
+    await req.expect.xmlBodyEquals(
       "<ModelWithUrlProperty><Url>https://myaccount.blob.core.windows.net/</Url></ModelWithUrlProperty>",
     );
     return { status: 201 };


### PR DESCRIPTION
A change on how to use the built-in request validation tools. All expectation are now under `req.expect` instead of directly under `req`. This makes it more obvious what is going to be a expecting a result vs just getting a value.