### PR TITLE
Add modelAsString to url encoding test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/src/test-routes/formdata.ts
+++ b/src/test-routes/formdata.ts
@@ -19,7 +19,7 @@ app.category("optional", () => {
       throw new ValidationError(`Expected petID 1 but got ${petId}`, undefined, request.params);
     }
     request.expect.containsHeader("content-type", "application/x-www-form-urlencoded");
-    request.expect.bodyEquals({ pet_type: "dog", pet_food: "meat", name: "Fido", status: "", pet_age: "42" });
+    request.expect.bodyEquals({ pet_type: "dog", pet_food: "meat", name: "Fido", pet_age: "42" });
     return {
       status: 200,
     };

--- a/swagger/body-formdata-urlencoded.json
+++ b/swagger/body-formdata-urlencoded.json
@@ -79,7 +79,11 @@
             "cat",
             "fish"
         ],
-        "x-ms-parameter-location": "method"
+        "x-ms-parameter-location": "method",
+        "x-ms-enum": {
+          "name": "PetType",
+          "modelAsString": false
+        }
     },
     "Pet_food": {
       "name": "pet_food",


### PR DESCRIPTION
- Changes generated code to something closer to our expectation
- https://gist.github.com/chamons/54eb354a28cceb1558379c6ba5664fcf
- Also  Remove status from expected body as it is optional, and we're no longer unconditionally sending