### PR TITLE
add multiapi version no mixins

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.0.19",
+  "version": "3.0.20",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/swagger/multiapi-v0.json
+++ b/swagger/multiapi-v0.json
@@ -1,0 +1,88 @@
+{
+    "swagger": "2.0",
+    "info": {
+      "title": "Multiapi Service Client",
+      "description": "Service client for multiapi client testing",
+      "version": "0.0.0"
+    },
+    "host": "localhost:3000",
+    "schemes": [
+      "http"
+    ],
+    "produces": [
+        "application/json"
+    ],
+    "paths": {
+        "/multiapi/one/testTwoEndpoint": {
+            "get": {
+                "operationId": "OperationGroupOne_testTwo",
+                "description": "TestTwo should be in OperationGroupOneOperations",
+                "x-ms-request-id": "request-id",
+                "parameters": [
+                    {
+                        "$ref": "#/parameters/ApiVersionParameter"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "The empty return value of testTwo"
+                    },
+                    "default": {
+                        "description": "Unexpected error",
+                        "schema": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    }
+                }
+            }
+      }
+    },
+    "definitions": {
+        "Error": {
+            "type":  "object",
+            "properties": {
+                "status": {
+                    "type": "integer",
+                    "format": "int32"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "PagingResult": {
+          "type":  "object",
+          "properties": {
+            "values": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            },
+            "nextLink": {
+              "type": "string"
+            }
+          }
+      },
+        "Product": {
+            "x-ms-azure-resource": true,
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "format": "int32"
+                }
+            }
+        }
+    },
+    "parameters": {
+        "ApiVersionParameter": {
+            "name": "api-version",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The API version to use for this operation.",
+            "minLength": 1
+        }
+    }
+}


### PR DESCRIPTION
Currently all of the multiapi operation versions all have mixin operations. Recently found a regression in multiapi versions without mixins, so adding this test.