### PR TITLE
Fix PetAPObject schema definition to match route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.0.23",
+  "version": "3.0.24",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/swagger/additionalProperties.json
+++ b/swagger/additionalProperties.json
@@ -259,9 +259,7 @@
           "readOnly": true
         }
       },
-      "additionalProperties": {
-        "type": "object"
-      }
+      "additionalProperties": {}
     },
     "PetAPString": {
       "type": "object",


### PR DESCRIPTION
The track 1 modeler didn't correctly interpret the schema definition,
and now that we fixed the behavior in track 2 the codegen doesn't match
what the route expects.
Fix the schema definition to match the route and not break tests.