### PR TITLE
Explicitly declare single-value enums as constants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.0.37",
+  "version": "3.0.38",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/swagger/azure-special-properties.json
+++ b/swagger/azure-special-properties.json
@@ -367,7 +367,7 @@
             "type": "string",
             "required": true,
             "enum": [ "2.0" ],
-            "x-ms-enum": { "name": "apiVersionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "x-ms-api-version": false
           }
         ],
@@ -447,7 +447,7 @@
           "type": "string",
           "required": true,
           "enum": [ "2.0" ],
-          "x-ms-enum": { "name": "apiVersionConst", "modelAsString": false },
+          "x-ms-enum": { "modelAsString": false },
           "x-ms-api-version": false
         }
       ],
@@ -510,7 +510,7 @@
             "type": "string",
             "required": true,
             "enum": [ "2.0" ],
-            "x-ms-enum": { "name": "apiVersionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "x-ms-api-version": false
           }
         ],
@@ -602,7 +602,7 @@
             "type": "string",
             "required": true,
             "enum": [ "path1/path2/path3" ],
-            "x-ms-enum": { "name": "pathParamConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "x-ms-skip-url-encoding": true
           }
         ],
@@ -722,7 +722,7 @@
             "description": "An unencoded query parameter with value 'value1&q2=value2&q3=value3'",
             "type": "string",
             "enum": [ "value1&q2=value2&q3=value3" ],
-            "x-ms-enum": { "name": "queryParamConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true,
             "x-ms-skip-url-encoding": true
           }
@@ -930,7 +930,7 @@
         "constantId": {
           "type": "integer",
           "enum": [ 1 ],
-          "x-ms-enum": { "name": "errorIdConst", "modelAsString": false }
+          "x-ms-enum": { "modelAsString": false }
         },
         "message": {
           "type": "string"

--- a/swagger/azure-special-properties.json
+++ b/swagger/azure-special-properties.json
@@ -367,6 +367,7 @@
             "type": "string",
             "required": true,
             "enum": [ "2.0" ],
+            "x-ms-enum": { "name": "apiVersionConst", "modelAsString": false },
             "x-ms-api-version": false
           }
         ],
@@ -446,6 +447,7 @@
           "type": "string",
           "required": true,
           "enum": [ "2.0" ],
+          "x-ms-enum": { "name": "apiVersionConst", "modelAsString": false },
           "x-ms-api-version": false
         }
       ],
@@ -508,6 +510,7 @@
             "type": "string",
             "required": true,
             "enum": [ "2.0" ],
+            "x-ms-enum": { "name": "apiVersionConst", "modelAsString": false },
             "x-ms-api-version": false
           }
         ],
@@ -599,6 +602,7 @@
             "type": "string",
             "required": true,
             "enum": [ "path1/path2/path3" ],
+            "x-ms-enum": { "name": "pathParamConst", "modelAsString": false },
             "x-ms-skip-url-encoding": true
           }
         ],
@@ -718,6 +722,7 @@
             "description": "An unencoded query parameter with value 'value1&q2=value2&q3=value3'",
             "type": "string",
             "enum": [ "value1&q2=value2&q3=value3" ],
+            "x-ms-enum": { "name": "queryParamConst", "modelAsString": false },
             "required": true,
             "x-ms-skip-url-encoding": true
           }
@@ -924,7 +929,8 @@
         },
         "constantId": {
           "type": "integer",
-          "enum": [ 1 ]
+          "enum": [ 1 ],
+          "x-ms-enum": { "name": "errorIdConst", "modelAsString": false }
         },
         "message": {
           "type": "string"

--- a/swagger/body-boolean.json
+++ b/swagger/body-boolean.json
@@ -29,7 +29,8 @@
                         "description": "The true Boolean value",
                         "schema": {
                             "type": "boolean",
-                            "enum": [true]
+                            "enum": [true],
+                            "x-ms-enum": { "name": "trueConst", "modelAsString": false }
                         }
                     },
                     "default": {
@@ -54,7 +55,8 @@
                         "in": "body",
                         "schema" : {
                             "type": "boolean",
-                            "enum": [true]
+                            "enum": [true],
+                            "x-ms-enum": { "name": "trueConst", "modelAsString": false }
                         },
                         "required": true
                     }
@@ -92,7 +94,8 @@
                         "description": "The false Boolean value",
                         "schema": {
                             "type": "boolean",
-                            "enum": [false]
+                            "enum": [false],
+                            "x-ms-enum": { "name": "falseConst", "modelAsString": false }
                         }
                     },
                     "default": {
@@ -117,7 +120,8 @@
                         "in": "body",
                         "schema" : {
                             "type": "boolean",
-                            "enum": [false]
+                            "enum": [false],
+                            "x-ms-enum": { "name": "falseConst", "modelAsString": false }
                         },
                         "required": true
                     }

--- a/swagger/body-boolean.json
+++ b/swagger/body-boolean.json
@@ -30,7 +30,7 @@
                         "schema": {
                             "type": "boolean",
                             "enum": [true],
-                            "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+                            "x-ms-enum": { "modelAsString": false }
                         }
                     },
                     "default": {
@@ -56,7 +56,7 @@
                         "schema" : {
                             "type": "boolean",
                             "enum": [true],
-                            "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+                            "x-ms-enum": { "modelAsString": false }
                         },
                         "required": true
                     }
@@ -95,7 +95,7 @@
                         "schema": {
                             "type": "boolean",
                             "enum": [false],
-                            "x-ms-enum": { "name": "falseConst", "modelAsString": false }
+                            "x-ms-enum": { "modelAsString": false }
                         }
                     },
                     "default": {
@@ -121,7 +121,7 @@
                         "schema" : {
                             "type": "boolean",
                             "enum": [false],
-                            "x-ms-enum": { "name": "falseConst", "modelAsString": false }
+                            "x-ms-enum": { "modelAsString": false }
                         },
                         "required": true
                     }

--- a/swagger/body-date.json
+++ b/swagger/body-date.json
@@ -211,7 +211,8 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "enum":  ["0000-01-01"]
+              "enum":  ["0000-01-01"],
+              "x-ms-enum": { "name": "dateConst", "modelAsString": false }
             }
           },
           "default": {

--- a/swagger/body-date.json
+++ b/swagger/body-date.json
@@ -212,7 +212,7 @@
               "type": "string",
               "format": "date",
               "enum":  ["0000-01-01"],
-              "x-ms-enum": { "name": "dateConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {

--- a/swagger/body-datetime-rfc1123.json
+++ b/swagger/body-datetime-rfc1123.json
@@ -217,7 +217,7 @@
               "enum": [
                 "Sun, 1 Jan 0001 00:00:00 GMT"
               ],
-              "x-ms-enum": { "name": "dateTimeRfc1123Const", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {

--- a/swagger/body-datetime-rfc1123.json
+++ b/swagger/body-datetime-rfc1123.json
@@ -216,7 +216,8 @@
               "format": "date-time-rfc1123",
               "enum": [
                 "Sun, 1 Jan 0001 00:00:00 GMT"
-              ]
+              ],
+              "x-ms-enum": { "name": "dateTimeRfc1123Const", "modelAsString": false }
             }
           },
           "default": {

--- a/swagger/body-datetime.json
+++ b/swagger/body-datetime.json
@@ -450,7 +450,8 @@
               "format": "date-time",
               "enum": [
                 "0001-01-01T00:00:00Z"
-              ]
+              ],
+              "x-ms-enum": { "name": "minDateTimeUtcConst", "modelAsString": false }
             }
           },
           "default": {
@@ -501,7 +502,8 @@
               "format": "date-time",
               "enum": [
                 "0001-01-01t00:00:00+14:00"
-              ]
+              ],
+              "x-ms-enum": { "name": "minDateTimePosOffsetConst", "modelAsString": false }
             }
           },
           "default": {
@@ -562,7 +564,8 @@
               "format": "date-time",
               "enum": [
                 "0001-01-01t00:00:00-14:00"
-              ]
+              ],
+              "x-ms-enum": { "name": "minDateTimeNegOffsetConst", "modelAsString": false }
             }
           },
           "default": {

--- a/swagger/body-datetime.json
+++ b/swagger/body-datetime.json
@@ -451,7 +451,7 @@
               "enum": [
                 "0001-01-01T00:00:00Z"
               ],
-              "x-ms-enum": { "name": "minDateTimeUtcConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -503,7 +503,7 @@
               "enum": [
                 "0001-01-01t00:00:00+14:00"
               ],
-              "x-ms-enum": { "name": "minDateTimePosOffsetConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -565,7 +565,7 @@
               "enum": [
                 "0001-01-01t00:00:00-14:00"
               ],
-              "x-ms-enum": { "name": "minDateTimeNegOffsetConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {

--- a/swagger/body-number.json
+++ b/swagger/body-number.json
@@ -152,7 +152,8 @@
             "schema": {
               "type": "number",
               "format": "float",
-              "enum":  [3.402823e+20]
+              "enum":  [3.402823e+20],
+              "x-ms-enum": { "name": "bigFloatConst", "modelAsString": false }
             }
           },
           "default": {
@@ -211,7 +212,8 @@
             "schema": {
               "type": "number",
               "format": "double",
-              "enum":  [2.5976931e+101]
+              "enum":  [2.5976931e+101],
+              "x-ms-enum": { "name": "bigDoubleConst", "modelAsString": false }
             }
           },
           "default": {
@@ -239,7 +241,8 @@
             "schema": {
               "type": "number",
               "format": "double",
-              "enum":  [99999999.99]
+              "enum":  [99999999.99],
+              "x-ms-enum": { "name": "bigDoublePosDecimalConst", "modelAsString": false }
             },
             "required": true
           }
@@ -270,7 +273,8 @@
             "schema": {
               "type": "number",
               "format": "double",
-              "enum":  [99999999.99]
+              "enum":  [99999999.99],
+              "x-ms-enum": { "name": "bigDoublePosDecimalConst", "modelAsString": false }
             }
           },
           "default": {
@@ -298,7 +302,8 @@
             "schema": {
               "type": "number",
               "format": "double",
-              "enum":  [-99999999.99]
+              "enum":  [-99999999.99],
+              "x-ms-enum": { "name": "bigDoubleNegDecimalConst", "modelAsString": false }
             },
             "required": true
           }
@@ -329,7 +334,8 @@
             "schema": {
               "type": "number",
               "format": "double",
-              "enum":  [-99999999.99]
+              "enum":  [-99999999.99],
+              "x-ms-enum": { "name": "bigDoubleNegDecimalConst", "modelAsString": false }
             }
           },
           "default": {
@@ -388,7 +394,8 @@
             "schema": {
               "type": "number",
               "format": "decimal",
-              "enum":  [2.5976931e+101]
+              "enum":  [2.5976931e+101],
+              "x-ms-enum": { "name": "bigDecimalConst", "modelAsString": false }
             }
           },
           "default": {
@@ -416,7 +423,8 @@
             "schema": {
               "type": "number",
               "format": "decimal",
-              "enum":  [99999999.99]
+              "enum":  [99999999.99],
+              "x-ms-enum": { "name": "bigDecimalPosConst", "modelAsString": false }
             },
             "required": true
           }
@@ -447,7 +455,8 @@
             "schema": {
               "type": "number",
               "format": "decimal",
-              "enum":  [99999999.99]
+              "enum":  [99999999.99],
+              "x-ms-enum": { "name": "bigDecimalPosConst", "modelAsString": false }
             }
           },
           "default": {
@@ -475,7 +484,8 @@
             "schema": {
               "type": "number",
               "format": "decimal",
-              "enum":  [-99999999.99]
+              "enum":  [-99999999.99],
+              "x-ms-enum": { "name": "bigDecimalNegConst", "modelAsString": false }
             },
             "required": true
           }
@@ -506,7 +516,8 @@
             "schema": {
               "type": "number",
               "format": "decimal",
-              "enum":  [-99999999.99]
+              "enum":  [-99999999.99],
+              "x-ms-enum": { "name": "bigDecimalNegConst", "modelAsString": false }
             }
           },
           "default": {
@@ -565,7 +576,8 @@
             "schema": {
               "type": "number",
               "format": "double",
-              "enum":  [3.402823e-20]
+              "enum":  [3.402823e-20],
+              "x-ms-enum": { "name": "smallFloatConst", "modelAsString": false }
             }
           },
           "default": {
@@ -624,7 +636,8 @@
             "schema": {
               "type": "number",
               "format": "double",
-              "enum":  [2.5976931e-101]
+              "enum":  [2.5976931e-101],
+              "x-ms-enum": { "name": "smallDoubleConst", "modelAsString": false }
             }
           },
           "default": {
@@ -683,7 +696,8 @@
             "schema": {
               "type": "number",
               "format": "decimal",
-              "enum":  [2.5976931e-101]
+              "enum":  [2.5976931e-101],
+              "x-ms-enum": { "name": "smallDecimalConst", "modelAsString": false }
             }
           },
           "default": {

--- a/swagger/body-number.json
+++ b/swagger/body-number.json
@@ -153,7 +153,7 @@
               "type": "number",
               "format": "float",
               "enum":  [3.402823e+20],
-              "x-ms-enum": { "name": "bigFloatConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -213,7 +213,7 @@
               "type": "number",
               "format": "double",
               "enum":  [2.5976931e+101],
-              "x-ms-enum": { "name": "bigDoubleConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -242,7 +242,7 @@
               "type": "number",
               "format": "double",
               "enum":  [99999999.99],
-              "x-ms-enum": { "name": "bigDoublePosDecimalConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             },
             "required": true
           }
@@ -274,7 +274,7 @@
               "type": "number",
               "format": "double",
               "enum":  [99999999.99],
-              "x-ms-enum": { "name": "bigDoublePosDecimalConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -303,7 +303,7 @@
               "type": "number",
               "format": "double",
               "enum":  [-99999999.99],
-              "x-ms-enum": { "name": "bigDoubleNegDecimalConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             },
             "required": true
           }
@@ -335,7 +335,7 @@
               "type": "number",
               "format": "double",
               "enum":  [-99999999.99],
-              "x-ms-enum": { "name": "bigDoubleNegDecimalConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -395,7 +395,7 @@
               "type": "number",
               "format": "decimal",
               "enum":  [2.5976931e+101],
-              "x-ms-enum": { "name": "bigDecimalConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -424,7 +424,7 @@
               "type": "number",
               "format": "decimal",
               "enum":  [99999999.99],
-              "x-ms-enum": { "name": "bigDecimalPosConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             },
             "required": true
           }
@@ -456,7 +456,7 @@
               "type": "number",
               "format": "decimal",
               "enum":  [99999999.99],
-              "x-ms-enum": { "name": "bigDecimalPosConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -485,7 +485,7 @@
               "type": "number",
               "format": "decimal",
               "enum":  [-99999999.99],
-              "x-ms-enum": { "name": "bigDecimalNegConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             },
             "required": true
           }
@@ -517,7 +517,7 @@
               "type": "number",
               "format": "decimal",
               "enum":  [-99999999.99],
-              "x-ms-enum": { "name": "bigDecimalNegConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -577,7 +577,7 @@
               "type": "number",
               "format": "double",
               "enum":  [3.402823e-20],
-              "x-ms-enum": { "name": "smallFloatConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -637,7 +637,7 @@
               "type": "number",
               "format": "double",
               "enum":  [2.5976931e-101],
-              "x-ms-enum": { "name": "smallDoubleConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -697,7 +697,7 @@
               "type": "number",
               "format": "decimal",
               "enum":  [2.5976931e-101],
-              "x-ms-enum": { "name": "smallDecimalConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {

--- a/swagger/body-string.json
+++ b/swagger/body-string.json
@@ -92,7 +92,8 @@
             "description": "The empty String value",
             "schema": {
               "type": "string",
-              "enum": [""]
+              "enum": [""],
+              "x-ms-enum": { "name": "emptyStringConst", "modelAsString": false }
             }
           },
           "default": {
@@ -118,7 +119,8 @@
             "in": "body",
             "schema": {
               "type": "string",
-              "enum": [""]
+              "enum": [""],
+              "x-ms-enum": { "name": "emptyStringConst", "modelAsString": false }
             },
             "required": true
           }
@@ -156,7 +158,8 @@
             "description": "The mbcs String value",
             "schema": {
               "type": "string",
-              "enum": [ "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€" ]
+              "enum": [ "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€" ],
+              "x-ms-enum": { "name": "mbcsStringConst", "modelAsString": false }
             }
           },
           "default": {
@@ -182,7 +185,8 @@
             "in": "body",
             "schema": {
               "type": "string",
-              "enum": [ "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€" ]
+              "enum": [ "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€" ],
+              "x-ms-enum": { "name": "mbcsStringConst", "modelAsString": false }
             },
             "required": true
           }
@@ -220,7 +224,8 @@
             "description": "The String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'",
             "schema": {
               "type": "string",
-              "enum": [ "    Now is the time for all good men to come to the aid of their country    " ]
+              "enum": [ "    Now is the time for all good men to come to the aid of their country    " ],
+              "x-ms-enum": { "name": "wsStringConst", "modelAsString": false }
             }
           },
           "default": {
@@ -246,7 +251,8 @@
             "in": "body",
             "schema": {
               "type": "string",
-              "enum": [ "    Now is the time for all good men to come to the aid of their country    " ]
+              "enum": [ "    Now is the time for all good men to come to the aid of their country    " ],
+              "x-ms-enum": { "name": "wsStringConst", "modelAsString": false }
             },
             "required": true
           }
@@ -610,15 +616,15 @@
     },
     "RefColorConstant": {
       "type":  "object",
-      "properties": {       
-        "ColorConstant": {   
+      "properties": {
+        "ColorConstant": {
           "x-ms-enum": { "name": "ColorConstant", "modelAsString": false},
           "type": "string",
           "enum": [ "green-color" ],
           "description": "Referenced Color Constant Description."
         },
-         "field1": {            
-          "type": "string",          
+         "field1": {
+          "type": "string",
           "description": "Sample string."
         }
       },

--- a/swagger/body-string.json
+++ b/swagger/body-string.json
@@ -93,7 +93,7 @@
             "schema": {
               "type": "string",
               "enum": [""],
-              "x-ms-enum": { "name": "emptyStringConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -120,7 +120,7 @@
             "schema": {
               "type": "string",
               "enum": [""],
-              "x-ms-enum": { "name": "emptyStringConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             },
             "required": true
           }
@@ -159,7 +159,7 @@
             "schema": {
               "type": "string",
               "enum": [ "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€" ],
-              "x-ms-enum": { "name": "mbcsStringConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -186,7 +186,7 @@
             "schema": {
               "type": "string",
               "enum": [ "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€" ],
-              "x-ms-enum": { "name": "mbcsStringConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             },
             "required": true
           }
@@ -225,7 +225,7 @@
             "schema": {
               "type": "string",
               "enum": [ "    Now is the time for all good men to come to the aid of their country    " ],
-              "x-ms-enum": { "name": "wsStringConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -252,7 +252,7 @@
             "schema": {
               "type": "string",
               "enum": [ "    Now is the time for all good men to come to the aid of their country    " ],
-              "x-ms-enum": { "name": "wsStringConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             },
             "required": true
           }

--- a/swagger/complex-model.json
+++ b/swagger/complex-model.json
@@ -258,7 +258,8 @@
       "description": "Subscription ID.",
       "required": true,
       "type": "string",
-      "enum": [ "123456" ]
+      "enum": [ "123456" ],
+      "x-ms-enum": { "name": "subscriptionIdConst", "modelAsString": false }
     },
     "ApiVersionParameter": {
       "name": "api-version",

--- a/swagger/complex-model.json
+++ b/swagger/complex-model.json
@@ -259,7 +259,7 @@
       "required": true,
       "type": "string",
       "enum": [ "123456" ],
-      "x-ms-enum": { "name": "subscriptionIdConst", "modelAsString": false }
+      "x-ms-enum": { "modelAsString": false }
     },
     "ApiVersionParameter": {
       "name": "api-version",

--- a/swagger/httpInfrastructure.json
+++ b/swagger/httpInfrastructure.json
@@ -25,7 +25,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           },
           "default": {
@@ -50,7 +51,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         }
@@ -69,7 +71,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         }
@@ -106,7 +109,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           },
           "default": {
@@ -129,7 +133,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           },
           "default": {
@@ -154,7 +159,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -184,7 +190,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -214,7 +221,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -244,7 +252,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -276,7 +285,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -306,7 +316,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -338,7 +349,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -368,7 +380,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -398,7 +411,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -428,7 +442,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -478,7 +493,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -508,7 +524,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -538,7 +555,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -568,7 +586,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -625,7 +644,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/head/200" ]
+                "enum": [ "/http/success/head/200" ],
+                "x-ms-enum": { "name": "head300Const", "modelAsString": false }
               }
             }
           },
@@ -653,7 +673,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/get/200" ]
+                "enum": [ "/http/success/get/200" ],
+                "x-ms-enum": { "name": "get300Const", "modelAsString": false }
               }
             },
             "schema": {
@@ -690,7 +711,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/head/200" ]
+                "enum": [ "/http/success/head/200" ],
+                "x-ms-enum": { "name": "head301Const", "modelAsString": false }
               }
             }
           },
@@ -718,7 +740,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/get/200" ]
+                "enum": [ "/http/success/get/200" ],
+                "x-ms-enum": { "name": "get301Const", "modelAsString": false }
               }
             }
           },
@@ -744,7 +767,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -755,7 +779,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/failure/500" ]
+                "enum": [ "/http/failure/500" ],
+                "x-ms-enum": { "name": "put301Const", "modelAsString": false }
               }
             }
           },
@@ -785,7 +810,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/head/200" ]
+                "enum": [ "/http/success/head/200" ],
+                "x-ms-enum": { "name": "head302Const", "modelAsString": false }
               }
             }
           },
@@ -813,7 +839,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/get/200" ]
+                "enum": [ "/http/success/get/200" ],
+                "x-ms-enum": { "name": "get302Const", "modelAsString": false }
               }
             }
           },
@@ -839,7 +866,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -850,7 +878,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/failure/500" ]
+                "enum": [ "/http/failure/500" ],
+                "x-ms-enum": { "name": "patch302Const", "modelAsString": false }
               }
             }
           },
@@ -878,7 +907,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -892,7 +922,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/get/200" ]
+                "enum": [ "/http/success/get/200" ],
+                "x-ms-enum": { "name": "post303Const", "modelAsString": false }
               }
             }
           },
@@ -922,7 +953,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/head/200" ]
+                "enum": [ "/http/success/head/200" ],
+                "x-ms-enum": { "name": "head307Const", "modelAsString": false }
               }
             }
           },
@@ -950,7 +982,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/get/200" ]
+                "enum": [ "/http/success/get/200" ],
+                "x-ms-enum": { "name": "get307Const", "modelAsString": false }
               }
             }
           },
@@ -978,7 +1011,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/options/200" ]
+                "enum": [ "/http/success/options/200" ],
+                "x-ms-enum": { "name": "options307Const", "modelAsString": false }
               }
             }
           },
@@ -1004,7 +1038,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1018,7 +1053,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/put/200" ]
+                "enum": [ "/http/success/put/200" ],
+                "x-ms-enum": { "name": "put307Const", "modelAsString": false }
               }
             }
           },
@@ -1044,7 +1080,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1058,7 +1095,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/patch/200" ]
+                "enum": [ "/http/success/patch/200" ],
+                "x-ms-enum": { "name": "patch307Const", "modelAsString": false }
               }
             }
           },
@@ -1084,7 +1122,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1098,7 +1137,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/post/200" ]
+                "enum": [ "/http/success/post/200" ],
+                "x-ms-enum": { "name": "post307Const", "modelAsString": false }
               }
             }
           },
@@ -1124,7 +1164,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1138,7 +1179,8 @@
               "Location": {
                 "description": "The redirect location for this request",
                 "type": "string",
-                "enum": [ "/http/success/delete/200" ]
+                "enum": [ "/http/success/delete/200" ],
+                "x-ms-enum": { "name": "delete307Const", "modelAsString": false }
               }
             }
           },
@@ -1211,7 +1253,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1238,7 +1281,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1265,7 +1309,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1292,7 +1337,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1387,7 +1433,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1416,7 +1463,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1445,7 +1493,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1474,7 +1523,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1503,7 +1553,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1598,7 +1649,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1627,7 +1679,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1656,7 +1709,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1702,7 +1756,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1780,7 +1835,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1807,7 +1863,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1856,7 +1913,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1886,7 +1944,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1934,7 +1993,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           },
           "default": {
@@ -1961,7 +2021,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -1991,7 +2052,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -2023,7 +2085,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],
@@ -2053,7 +2116,8 @@
             "schema": {
               "description": "Simple boolean value true",
               "type": "boolean",
-              "enum": [ true ]
+              "enum": [ true ],
+              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
             }
           }
         ],

--- a/swagger/httpInfrastructure.json
+++ b/swagger/httpInfrastructure.json
@@ -26,7 +26,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -52,7 +52,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         }
@@ -72,7 +72,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         }
@@ -110,7 +110,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -134,7 +134,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -160,7 +160,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -191,7 +191,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -222,7 +222,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -253,7 +253,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -286,7 +286,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -317,7 +317,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -350,7 +350,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -381,7 +381,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -412,7 +412,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -443,7 +443,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -494,7 +494,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -525,7 +525,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -556,7 +556,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -587,7 +587,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -645,7 +645,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/head/200" ],
-                "x-ms-enum": { "name": "head300Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -674,7 +674,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/get/200" ],
-                "x-ms-enum": { "name": "get300Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             },
             "schema": {
@@ -712,7 +712,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/head/200" ],
-                "x-ms-enum": { "name": "head301Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -741,7 +741,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/get/200" ],
-                "x-ms-enum": { "name": "get301Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -768,7 +768,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -780,7 +780,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/failure/500" ],
-                "x-ms-enum": { "name": "put301Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -811,7 +811,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/head/200" ],
-                "x-ms-enum": { "name": "head302Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -840,7 +840,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/get/200" ],
-                "x-ms-enum": { "name": "get302Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -867,7 +867,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -879,7 +879,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/failure/500" ],
-                "x-ms-enum": { "name": "patch302Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -908,7 +908,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -923,7 +923,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/get/200" ],
-                "x-ms-enum": { "name": "post303Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -954,7 +954,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/head/200" ],
-                "x-ms-enum": { "name": "head307Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -983,7 +983,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/get/200" ],
-                "x-ms-enum": { "name": "get307Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -1012,7 +1012,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/options/200" ],
-                "x-ms-enum": { "name": "options307Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -1039,7 +1039,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1054,7 +1054,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/put/200" ],
-                "x-ms-enum": { "name": "put307Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -1081,7 +1081,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1096,7 +1096,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/patch/200" ],
-                "x-ms-enum": { "name": "patch307Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -1123,7 +1123,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1138,7 +1138,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/post/200" ],
-                "x-ms-enum": { "name": "post307Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -1165,7 +1165,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1180,7 +1180,7 @@
                 "description": "The redirect location for this request",
                 "type": "string",
                 "enum": [ "/http/success/delete/200" ],
-                "x-ms-enum": { "name": "delete307Const", "modelAsString": false }
+                "x-ms-enum": { "modelAsString": false }
               }
             }
           },
@@ -1254,7 +1254,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1282,7 +1282,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1310,7 +1310,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1338,7 +1338,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1434,7 +1434,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1464,7 +1464,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1494,7 +1494,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1524,7 +1524,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1554,7 +1554,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1650,7 +1650,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1680,7 +1680,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1710,7 +1710,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1757,7 +1757,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1836,7 +1836,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1864,7 +1864,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1914,7 +1914,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1945,7 +1945,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -1994,7 +1994,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           },
           "default": {
@@ -2022,7 +2022,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -2053,7 +2053,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -2086,7 +2086,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],
@@ -2117,7 +2117,7 @@
               "description": "Simple boolean value true",
               "type": "boolean",
               "enum": [ true ],
-              "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+              "x-ms-enum": { "modelAsString": false }
             }
           }
         ],

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -159,7 +159,7 @@
             "enum": [
               true
             ],
-            "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+            "x-ms-enum": { "modelAsString": false }
           }
 		    ],
         "responses": {
@@ -190,7 +190,7 @@
             "enum": [
               true
             ],
-            "x-ms-enum": { "name": "trueConst", "modelAsString": false }
+            "x-ms-enum": { "modelAsString": false }
           }
 		    ],
         "responses": {

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -158,7 +158,8 @@
             "type": "boolean",
             "enum": [
               true
-            ]
+            ],
+            "x-ms-enum": { "name": "trueConst", "modelAsString": false }
           }
 		    ],
         "responses": {
@@ -188,7 +189,8 @@
             "type": "boolean",
             "enum": [
               true
-            ]
+            ],
+            "x-ms-enum": { "name": "trueConst", "modelAsString": false }
           }
 		    ],
         "responses": {

--- a/swagger/url.json
+++ b/swagger/url.json
@@ -26,7 +26,7 @@
             "description": "true boolean value",
             "type": "boolean",
             "enum": [ true ],
-            "x-ms-enum": { "name": "trueConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -57,7 +57,7 @@
             "description": "false boolean value",
             "type": "boolean",
             "enum": [ false ],
-            "x-ms-enum": { "name": "falseConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -88,7 +88,7 @@
             "description": "'1000000' integer value",
             "type": "integer",
             "enum": [ 1000000 ],
-            "x-ms-enum": { "name": "oneMillionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -119,7 +119,7 @@
             "description": "'-1000000' integer value",
             "type": "integer",
             "enum": [ -1000000 ],
-            "x-ms-enum": { "name": "negOneMillionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -151,7 +151,7 @@
             "type": "integer",
             "format": "int64",
             "enum": [ 10000000000 ],
-            "x-ms-enum": { "name": "tenBillionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -183,7 +183,7 @@
             "type": "integer",
             "format": "int64",
             "enum": [ -10000000000 ],
-            "x-ms-enum": { "name": "negTenBillionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -214,7 +214,7 @@
             "description": "'1.034E+20'numeric value",
             "type": "number",
             "enum": [ 1.034E+20 ],
-            "x-ms-enum": { "name": "posScientificConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -245,7 +245,7 @@
             "description": "'-1.034E-20'numeric value",
             "type": "number",
             "enum": [ -1.034E-20 ],
-            "x-ms-enum": { "name": "negScientificConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -277,7 +277,7 @@
             "type": "number",
             "format": "double",
             "enum": [ 9999999.999 ],
-            "x-ms-enum": { "name": "posDecimalConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -309,7 +309,7 @@
             "type": "number",
             "format": "double",
             "enum": [ -9999999.999 ],
-            "x-ms-enum": { "name": "negDecimalConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -340,7 +340,7 @@
             "description": "'啊齄丂狛狜隣郎隣兀﨩'multi-byte string value",
             "type": "string",
             "enum": [ "啊齄丂狛狜隣郎隣兀﨩" ],
-            "x-ms-enum": { "name": "unicodeConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -371,7 +371,7 @@
             "description": "'begin!*'();:@ &=+$,/?#[]end' url encoded string value",
             "type": "string",
             "enum": [ "begin!*'();:@ &=+$,/?#[]end" ],
-            "x-ms-enum": { "name": "urlEncodedConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -403,7 +403,7 @@
             "description": "'begin!*'();:@&=+$,end' url encoded string value",
             "type": "string",
             "enum": [ "begin!*'();:@&=+$,end" ],
-            "x-ms-enum": { "name": "nonUrlEncodedConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true,
             "x-ms-skip-url-encoding": true
           }
@@ -435,7 +435,7 @@
             "description": "'' string value",
             "type": "string",
             "enum": [ "" ],
-            "x-ms-enum": { "name": "emptyStringConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -588,7 +588,7 @@
             "type": "string",
             "format": "byte",
             "enum": [ "" ],
-            "x-ms-enum": { "name": "emptyByteConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -650,7 +650,7 @@
             "type": "string",
             "format": "date",
             "enum": [ "2012-01-01" ],
-            "x-ms-enum": { "name": "dateConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -712,7 +712,7 @@
             "type": "string",
             "format": "date-time",
             "enum": [ "2012-01-01T01:01:01Z" ],
-            "x-ms-enum": { "name": "dateTimeConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -866,7 +866,7 @@
             "description": "true boolean value",
             "type": "boolean",
             "enum": [ true ],
-            "x-ms-enum": { "name": "trueConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -897,7 +897,7 @@
             "description": "false boolean value",
             "type": "boolean",
             "enum": [ false ],
-            "x-ms-enum": { "name": "falseConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -956,7 +956,7 @@
             "description": "'1000000' integer value",
             "type": "integer",
             "enum": [ 1000000 ],
-            "x-ms-enum": { "name": "oneMillionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -987,7 +987,7 @@
             "description": "'-1000000' integer value",
             "type": "integer",
             "enum": [ -1000000 ],
-            "x-ms-enum": { "name": "negOneMillionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1047,7 +1047,7 @@
             "type": "integer",
             "format": "int64",
             "enum": [ 10000000000 ],
-            "x-ms-enum": { "name": "tenBillionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1079,7 +1079,7 @@
             "type": "integer",
             "format": "int64",
             "enum": [ -10000000000 ],
-            "x-ms-enum": { "name": "negTenBillionConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1139,7 +1139,7 @@
             "description": "'1.034E+20'numeric value",
             "type": "number",
             "enum": [ 1.034E+20 ],
-            "x-ms-enum": { "name": "posScientificConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1170,7 +1170,7 @@
             "description": "'-1.034E-20'numeric value",
             "type": "number",
             "enum": [ -1.034E-20 ],
-            "x-ms-enum": { "name": "negScientificConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1230,7 +1230,7 @@
             "type": "number",
             "format": "double",
             "enum": [ 9999999.999 ],
-            "x-ms-enum": { "name": "posDecimalConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1262,7 +1262,7 @@
             "type": "number",
             "format": "double",
             "enum": [ -9999999.999 ],
-            "x-ms-enum": { "name": "negDecimalConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1322,7 +1322,7 @@
             "description": "'啊齄丂狛狜隣郎隣兀﨩'multi-byte string value",
             "type": "string",
             "enum": [ "啊齄丂狛狜隣郎隣兀﨩" ],
-            "x-ms-enum": { "name": "unicodeConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1353,7 +1353,7 @@
             "description": "'begin!*'();:@ &=+$,/?#[]end' url encoded string value",
             "type": "string",
             "enum": [ "begin!*'();:@ &=+$,/?#[]end" ],
-            "x-ms-enum": { "name": "urlEncodedConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1384,7 +1384,7 @@
             "description": "'' string value",
             "type": "string",
             "enum": [ "" ],
-            "x-ms-enum": { "name": "emptyStringConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1533,7 +1533,7 @@
             "type": "string",
             "format": "byte",
             "enum": [ "" ],
-            "x-ms-enum": { "name": "emptyByteConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1594,7 +1594,7 @@
             "type": "string",
             "format": "date",
             "enum": [ "2012-01-01" ],
-            "x-ms-enum": { "name": "dateConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -1655,7 +1655,7 @@
             "type": "string",
             "format": "date-time",
             "enum": [ "2012-01-01T01:01:01Z" ],
-            "x-ms-enum": { "name": "dateTimeConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],

--- a/swagger/url.json
+++ b/swagger/url.json
@@ -26,6 +26,7 @@
             "description": "true boolean value",
             "type": "boolean",
             "enum": [ true ],
+            "x-ms-enum": { "name": "trueConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -56,6 +57,7 @@
             "description": "false boolean value",
             "type": "boolean",
             "enum": [ false ],
+            "x-ms-enum": { "name": "falseConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -86,6 +88,7 @@
             "description": "'1000000' integer value",
             "type": "integer",
             "enum": [ 1000000 ],
+            "x-ms-enum": { "name": "oneMillionConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -116,6 +119,7 @@
             "description": "'-1000000' integer value",
             "type": "integer",
             "enum": [ -1000000 ],
+            "x-ms-enum": { "name": "negOneMillionConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -147,6 +151,7 @@
             "type": "integer",
             "format": "int64",
             "enum": [ 10000000000 ],
+            "x-ms-enum": { "name": "tenBillionConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -178,6 +183,7 @@
             "type": "integer",
             "format": "int64",
             "enum": [ -10000000000 ],
+            "x-ms-enum": { "name": "negTenBillionConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -208,6 +214,7 @@
             "description": "'1.034E+20'numeric value",
             "type": "number",
             "enum": [ 1.034E+20 ],
+            "x-ms-enum": { "name": "posScientificConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -238,6 +245,7 @@
             "description": "'-1.034E-20'numeric value",
             "type": "number",
             "enum": [ -1.034E-20 ],
+            "x-ms-enum": { "name": "negScientificConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -269,6 +277,7 @@
             "type": "number",
             "format": "double",
             "enum": [ 9999999.999 ],
+            "x-ms-enum": { "name": "posDecimalConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -300,6 +309,7 @@
             "type": "number",
             "format": "double",
             "enum": [ -9999999.999 ],
+            "x-ms-enum": { "name": "negDecimalConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -330,6 +340,7 @@
             "description": "'啊齄丂狛狜隣郎隣兀﨩'multi-byte string value",
             "type": "string",
             "enum": [ "啊齄丂狛狜隣郎隣兀﨩" ],
+            "x-ms-enum": { "name": "unicodeConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -360,6 +371,7 @@
             "description": "'begin!*'();:@ &=+$,/?#[]end' url encoded string value",
             "type": "string",
             "enum": [ "begin!*'();:@ &=+$,/?#[]end" ],
+            "x-ms-enum": { "name": "urlEncodedConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -391,6 +403,7 @@
             "description": "'begin!*'();:@&=+$,end' url encoded string value",
             "type": "string",
             "enum": [ "begin!*'();:@&=+$,end" ],
+            "x-ms-enum": { "name": "nonUrlEncodedConst", "modelAsString": false },
             "required": true,
             "x-ms-skip-url-encoding": true
           }
@@ -422,6 +435,7 @@
             "description": "'' string value",
             "type": "string",
             "enum": [ "" ],
+            "x-ms-enum": { "name": "emptyStringConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -574,6 +588,7 @@
             "type": "string",
             "format": "byte",
             "enum": [ "" ],
+            "x-ms-enum": { "name": "emptyByteConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -635,6 +650,7 @@
             "type": "string",
             "format": "date",
             "enum": [ "2012-01-01" ],
+            "x-ms-enum": { "name": "dateConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -696,6 +712,7 @@
             "type": "string",
             "format": "date-time",
             "enum": [ "2012-01-01T01:01:01Z" ],
+            "x-ms-enum": { "name": "dateTimeConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -849,6 +866,7 @@
             "description": "true boolean value",
             "type": "boolean",
             "enum": [ true ],
+            "x-ms-enum": { "name": "trueConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -879,6 +897,7 @@
             "description": "false boolean value",
             "type": "boolean",
             "enum": [ false ],
+            "x-ms-enum": { "name": "falseConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -937,6 +956,7 @@
             "description": "'1000000' integer value",
             "type": "integer",
             "enum": [ 1000000 ],
+            "x-ms-enum": { "name": "oneMillionConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -967,6 +987,7 @@
             "description": "'-1000000' integer value",
             "type": "integer",
             "enum": [ -1000000 ],
+            "x-ms-enum": { "name": "negOneMillionConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1026,6 +1047,7 @@
             "type": "integer",
             "format": "int64",
             "enum": [ 10000000000 ],
+            "x-ms-enum": { "name": "tenBillionConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1057,6 +1079,7 @@
             "type": "integer",
             "format": "int64",
             "enum": [ -10000000000 ],
+            "x-ms-enum": { "name": "negTenBillionConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1116,6 +1139,7 @@
             "description": "'1.034E+20'numeric value",
             "type": "number",
             "enum": [ 1.034E+20 ],
+            "x-ms-enum": { "name": "posScientificConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1146,6 +1170,7 @@
             "description": "'-1.034E-20'numeric value",
             "type": "number",
             "enum": [ -1.034E-20 ],
+            "x-ms-enum": { "name": "negScientificConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1205,6 +1230,7 @@
             "type": "number",
             "format": "double",
             "enum": [ 9999999.999 ],
+            "x-ms-enum": { "name": "posDecimalConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1236,6 +1262,7 @@
             "type": "number",
             "format": "double",
             "enum": [ -9999999.999 ],
+            "x-ms-enum": { "name": "negDecimalConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1295,6 +1322,7 @@
             "description": "'啊齄丂狛狜隣郎隣兀﨩'multi-byte string value",
             "type": "string",
             "enum": [ "啊齄丂狛狜隣郎隣兀﨩" ],
+            "x-ms-enum": { "name": "unicodeConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1325,6 +1353,7 @@
             "description": "'begin!*'();:@ &=+$,/?#[]end' url encoded string value",
             "type": "string",
             "enum": [ "begin!*'();:@ &=+$,/?#[]end" ],
+            "x-ms-enum": { "name": "urlEncodedConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1355,6 +1384,7 @@
             "description": "'' string value",
             "type": "string",
             "enum": [ "" ],
+            "x-ms-enum": { "name": "emptyStringConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1503,6 +1533,7 @@
             "type": "string",
             "format": "byte",
             "enum": [ "" ],
+            "x-ms-enum": { "name": "emptyByteConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1563,6 +1594,7 @@
             "type": "string",
             "format": "date",
             "enum": [ "2012-01-01" ],
+            "x-ms-enum": { "name": "dateConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -1623,6 +1655,7 @@
             "type": "string",
             "format": "date-time",
             "enum": [ "2012-01-01T01:01:01Z" ],
+            "x-ms-enum": { "name": "dateTimeConst", "modelAsString": false },
             "required": true
           }
         ],

--- a/swagger/validation.json
+++ b/swagger/validation.json
@@ -123,7 +123,7 @@
             "name": "constantParam",
             "type": "string",
             "enum": ["constant"],
-            "x-ms-enum": { "name": "constantConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "in": "path",
             "required": true
           }
@@ -141,7 +141,7 @@
             "name": "constantParam",
             "type": "string",
             "enum": ["constant"],
-            "x-ms-enum": { "name": "constantConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "in": "path",
             "required": true
           },
@@ -199,13 +199,13 @@
           "type": "integer",
           "description": "Constant int",
           "enum": [0],
-          "x-ms-enum": { "name": "zeroConst", "modelAsString": false }
+          "x-ms-enum": { "modelAsString": false }
         },
         "constString": {
           "type": "string",
           "description": "Constant string",
           "enum": ["constant"],
-          "x-ms-enum": { "name": "constantConst", "modelAsString": false }
+          "x-ms-enum": { "modelAsString": false }
         },
         "constStringAsEnum": {
           "type": "string",
@@ -227,7 +227,7 @@
           "type": "string",
           "description": "Constant string",
           "enum": ["constant"],
-          "x-ms-enum": { "name": "constantConst", "modelAsString": false }
+          "x-ms-enum": { "modelAsString": false }
         },
         "count": {
           "type": "integer",
@@ -244,13 +244,13 @@
           "type": "string",
           "description": "Constant string",
           "enum": ["constant"],
-          "x-ms-enum": { "name": "constantConst", "modelAsString": false }
+          "x-ms-enum": { "modelAsString": false }
         },
         "constProperty2": {
           "type": "string",
           "description": "Constant string2",
           "enum": ["constant2"],
-          "x-ms-enum": { "name": "constant2Const", "modelAsString": false }
+          "x-ms-enum": { "modelAsString": false }
         }
       }
     },

--- a/swagger/validation.json
+++ b/swagger/validation.json
@@ -123,6 +123,7 @@
             "name": "constantParam",
             "type": "string",
             "enum": ["constant"],
+            "x-ms-enum": { "name": "constantConst", "modelAsString": false },
             "in": "path",
             "required": true
           }
@@ -140,6 +141,7 @@
             "name": "constantParam",
             "type": "string",
             "enum": ["constant"],
+            "x-ms-enum": { "name": "constantConst", "modelAsString": false },
             "in": "path",
             "required": true
           },
@@ -196,12 +198,14 @@
         "constInt": {
           "type": "integer",
           "description": "Constant int",
-          "enum": [0]
+          "enum": [0],
+          "x-ms-enum": { "name": "zeroConst", "modelAsString": false }
         },
         "constString": {
           "type": "string",
           "description": "Constant string",
-          "enum": ["constant"]
+          "enum": ["constant"],
+          "x-ms-enum": { "name": "constantConst", "modelAsString": false }
         },
         "constStringAsEnum": {
           "type": "string",
@@ -222,7 +226,8 @@
         "constProperty": {
           "type": "string",
           "description": "Constant string",
-          "enum": ["constant"]
+          "enum": ["constant"],
+          "x-ms-enum": { "name": "constantConst", "modelAsString": false }
         },
         "count": {
           "type": "integer",
@@ -238,12 +243,14 @@
         "constProperty": {
           "type": "string",
           "description": "Constant string",
-          "enum": ["constant"]
+          "enum": ["constant"],
+          "x-ms-enum": { "name": "constantConst", "modelAsString": false }
         },
         "constProperty2": {
           "type": "string",
           "description": "Constant string2",
-          "enum": ["constant2"]
+          "enum": ["constant2"],
+          "x-ms-enum": { "name": "constant2Const", "modelAsString": false }
         }
       }
     },

--- a/swagger/xml-service.json
+++ b/swagger/xml-service.json
@@ -498,7 +498,7 @@
             "enum": [
               "list"
             ],
-            "x-ms-enum": { "name": "listConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -527,7 +527,7 @@
             "enum": [
               "properties"
             ],
-            "x-ms-enum": { "name": "propertiesConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           },
           {
@@ -537,7 +537,7 @@
             "enum": [
               "service"
             ],
-            "x-ms-enum": { "name": "serviceConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -564,7 +564,7 @@
             "enum": [
               "properties"
             ],
-            "x-ms-enum": { "name": "propertiesConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           },
           {
@@ -574,7 +574,7 @@
             "enum": [
               "service"
             ],
-            "x-ms-enum": { "name": "serviceConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           },
           {
@@ -608,7 +608,7 @@
             "enum": [
               "acl"
             ],
-            "x-ms-enum": { "name": "aclConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           },
           {
@@ -618,7 +618,7 @@
             "enum": [
               "container"
             ],
-            "x-ms-enum": { "name": "containerConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],
@@ -645,7 +645,7 @@
             "enum": [
               "acl"
             ],
-            "x-ms-enum": { "name": "aclConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           },
           {
@@ -655,7 +655,7 @@
             "enum": [
               "container"
             ],
-            "x-ms-enum": { "name": "containerConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           },
           {
@@ -689,7 +689,7 @@
             "enum": [
               "list"
             ],
-            "x-ms-enum": { "name": "listConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           },
           {
@@ -699,7 +699,7 @@
             "enum": [
               "container"
             ],
-            "x-ms-enum": { "name": "containerConst", "modelAsString": false },
+            "x-ms-enum": { "modelAsString": false },
             "required": true
           }
         ],

--- a/swagger/xml-service.json
+++ b/swagger/xml-service.json
@@ -498,6 +498,7 @@
             "enum": [
               "list"
             ],
+            "x-ms-enum": { "name": "listConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -526,6 +527,7 @@
             "enum": [
               "properties"
             ],
+            "x-ms-enum": { "name": "propertiesConst", "modelAsString": false },
             "required": true
           },
           {
@@ -535,6 +537,7 @@
             "enum": [
               "service"
             ],
+            "x-ms-enum": { "name": "serviceConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -561,6 +564,7 @@
             "enum": [
               "properties"
             ],
+            "x-ms-enum": { "name": "propertiesConst", "modelAsString": false },
             "required": true
           },
           {
@@ -570,6 +574,7 @@
             "enum": [
               "service"
             ],
+            "x-ms-enum": { "name": "serviceConst", "modelAsString": false },
             "required": true
           },
           {
@@ -603,6 +608,7 @@
             "enum": [
               "acl"
             ],
+            "x-ms-enum": { "name": "aclConst", "modelAsString": false },
             "required": true
           },
           {
@@ -612,6 +618,7 @@
             "enum": [
               "container"
             ],
+            "x-ms-enum": { "name": "containerConst", "modelAsString": false },
             "required": true
           }
         ],
@@ -638,6 +645,7 @@
             "enum": [
               "acl"
             ],
+            "x-ms-enum": { "name": "aclConst", "modelAsString": false },
             "required": true
           },
           {
@@ -647,6 +655,7 @@
             "enum": [
               "container"
             ],
+            "x-ms-enum": { "name": "containerConst", "modelAsString": false },
             "required": true
           },
           {
@@ -680,6 +689,7 @@
             "enum": [
               "list"
             ],
+            "x-ms-enum": { "name": "listConst", "modelAsString": false },
             "required": true
           },
           {
@@ -689,6 +699,7 @@
             "enum": [
               "container"
             ],
+            "x-ms-enum": { "name": "containerConst", "modelAsString": false },
             "required": true
           }
         ],


### PR DESCRIPTION
Previous modelers made the assumption that single-value enums were
constant values which lead to some inconsistencies.
Update swaggers where the intent was to treat the enums as constants.