### PR TITLE
Be explicit in the consumes media type value

### DIFF
--- a/legacy/routes/mediatypes.js
+++ b/legacy/routes/mediatypes.js
@@ -28,7 +28,7 @@ var mediatypes = function (coverage) {
   });
   router.post("/contentTypeWithEncoding", function (req, res, next) {
     let content_type = req.headers["content-type"];
-    if (content_type === "text/plain; encoding=UTF-8") {
+    if (content_type === "text/plain; charset=UTF-8") {
       coverage["MediaTypeWithEncoding"]++;
       res.status(200).json("Nice job sending content type with encoding");
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/swagger/media_types.json
+++ b/swagger/media_types.json
@@ -51,9 +51,9 @@
     },
     "/mediatypes/contentTypeWithEncoding": {
       "post": {
-        "description": "Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter",
+        "description": "Pass in contentType 'text/plain; charset=UTF-8' to pass test. Value for input does not matter",
         "operationId": "contentTypeWithEncoding",
-        "consumes": ["text/plain"],
+        "consumes": ["text/plain; charset=UTF-8"],
         "produces": ["application/json"],
         "parameters": [
           {
@@ -67,7 +67,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Received 'text/plain; encoding=UTF-8' as contentType",
+            "description": "Received 'text/plain; charset=UTF-8' as contentType",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
This way the value can be used verbatim when forming the request.