### PR TITLE
Add two tests for lro patch method

### DIFF
--- a/legacy/routes/lros.js
+++ b/legacy/routes/lros.js
@@ -109,21 +109,26 @@ var lros = function (coverage) {
   });
 
   router.get("/patch/201/retry/onlyAsyncHeader/operationStatuses/201", function (req, res, next) {
-    coverage["LROPatch201WithAsyncHeader"]++;
-    var status = "Accepted";
-    if (coverage["LROPatch201WithAsyncHeader"] === 2) {
-      status = "Updating";
-    } else if (coverage["LROPatch201WithAsyncHeader"] === 3) {
-      status = "Succeeded";
-    }
-    res
+    var scenario = "LROPatch201WithAsyncHeader";
+    console.log("In scenario: " + scenario + "\n");
+    if (!hasScenarioCookie(req, scenario)) {
+      addScenarioCookie(res, scenario);
+      res
       .status(200)
       .type("json")
       .end(
-        '{ "id": "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", "name": "201", "resourceId": "/lro/patch/201/retry/onlyAsyncHeader", "status": "' +
-          status +
-          '" }',
+        '{ "id": "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", "name": "201", "resourceId": "/lro/patch/201/retry/onlyAsyncHeader", "status": "Accepted" }',
       );
+    } else {
+      coverage[scenario]++;
+      removeScenarioCookie(res);
+      res
+      .status(200)
+      .type("json")
+      .end(
+        '{ "id": "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", "name": "201", "resourceId": "/lro/patch/201/retry/onlyAsyncHeader", "status": "Succeeded" }',
+      );
+    }
   });
 
   router.get("/patch/202/retry/asyncAndLocationHeader", function (req, res, next) {
@@ -152,15 +157,22 @@ var lros = function (coverage) {
   });
 
   router.get("/patch/202/retry/asyncAndLocationHeader/operationResults/202", function (req, res, next) {
-    coverage["LROPatch202WithAsyncAndLocationHeader"]++;
-    var status = "InProgress";
-    if (coverage["LROPatch202WithAsyncAndLocationHeader"] === 2) {
-      status = "Succeeded";
-    }
-    res
+    var scenario = "LROPatch202WithAsyncAndLocationHeader";
+    console.log("In scenario: " + scenario + "\n");
+    if (!hasScenarioCookie(req, scenario)) {
+      addScenarioCookie(res, scenario);
+      res
       .status(200)
       .type("json")
-      .end('{ "status": "' + status + '" }');
+      .end('{ "status": "InProgress" }');
+    } else {
+      coverage[scenario]++;
+      removeScenarioCookie(res);
+      res
+      .status(200)
+      .type("json")
+      .end('{ "status": "Succeeded" }');
+    }
   });
 
   router.get(

--- a/legacy/routes/lros.js
+++ b/legacy/routes/lros.js
@@ -114,20 +114,20 @@ var lros = function (coverage) {
     if (!hasScenarioCookie(req, scenario)) {
       addScenarioCookie(res, scenario);
       res
-      .status(200)
-      .type("json")
-      .end(
-        '{ "id": "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", "name": "201", "resourceId": "/lro/patch/201/retry/onlyAsyncHeader", "status": "Accepted" }',
-      );
+        .status(200)
+        .type("json")
+        .end(
+          '{ "id": "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", "name": "201", "resourceId": "/lro/patch/201/retry/onlyAsyncHeader", "status": "Accepted" }',
+        );
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
       res
-      .status(200)
-      .type("json")
-      .end(
-        '{ "id": "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", "name": "201", "resourceId": "/lro/patch/201/retry/onlyAsyncHeader", "status": "Succeeded" }',
-      );
+        .status(200)
+        .type("json")
+        .end(
+          '{ "id": "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", "name": "201", "resourceId": "/lro/patch/201/retry/onlyAsyncHeader", "status": "Succeeded" }',
+        );
     }
   });
 
@@ -161,17 +161,11 @@ var lros = function (coverage) {
     console.log("In scenario: " + scenario + "\n");
     if (!hasScenarioCookie(req, scenario)) {
       addScenarioCookie(res, scenario);
-      res
-      .status(200)
-      .type("json")
-      .end('{ "status": "InProgress" }');
+      res.status(200).type("json").end('{ "status": "InProgress" }');
     } else {
       coverage[scenario]++;
       removeScenarioCookie(res);
-      res
-      .status(200)
-      .type("json")
-      .end('{ "status": "Succeeded" }');
+      res.status(200).type("json").end('{ "status": "Succeeded" }');
     }
   });
 

--- a/legacy/routes/lros.js
+++ b/legacy/routes/lros.js
@@ -87,53 +87,93 @@ var lros = function (coverage) {
   });
 
   router.get("/patch/201/retry/onlyAsyncHeader", function (req, res, next) {
-    res.status(200).type("json").end('{ "properties": { "provisioningState": "Succeeded"}, "id": "/lro/patch/201/retry/onlyAsyncHeader", "name": "foo" }');
+    res
+      .status(200)
+      .type("json")
+      .end(
+        '{ "properties": { "provisioningState": "Succeeded"}, "id": "/lro/patch/201/retry/onlyAsyncHeader", "name": "foo" }',
+      );
   });
 
   router.patch("/patch/201/retry/onlyAsyncHeader", function (req, res, next) {
     var headers = {
       "Azure-AsyncOperation": getRequestBaseUrl(req) + "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201",
     };
-    res.set(headers).status(201).type("json")
-      .end('{ "properties": { "provisioningState": "Accepted"}, "id": "/lro/patch/201/retry/onlyAsyncHeader", "name": "foo" }');
+    res
+      .set(headers)
+      .status(201)
+      .type("json")
+      .end(
+        '{ "properties": { "provisioningState": "Accepted"}, "id": "/lro/patch/201/retry/onlyAsyncHeader", "name": "foo" }',
+      );
   });
 
   router.get("/patch/201/retry/onlyAsyncHeader/operationStatuses/201", function (req, res, next) {
     coverage["LROPatch201WithAsyncHeader"]++;
     var status = "Accepted";
-    if(coverage["LROPatch201WithAsyncHeader"] === 2) {
+    if (coverage["LROPatch201WithAsyncHeader"] === 2) {
       status = "Updating";
-    } else if(coverage["LROPatch201WithAsyncHeader"] === 3) {
+    } else if (coverage["LROPatch201WithAsyncHeader"] === 3) {
       status = "Succeeded";
     }
-    res.status(200).type("json").end('{ "id": "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", "name": "201", "resourceId": "/lro/patch/201/retry/onlyAsyncHeader", "status": "' + status + '" }');
+    res
+      .status(200)
+      .type("json")
+      .end(
+        '{ "id": "/lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201", "name": "201", "resourceId": "/lro/patch/201/retry/onlyAsyncHeader", "status": "' +
+          status +
+          '" }',
+      );
   });
 
   router.get("/patch/202/retry/asyncAndLocationHeader", function (req, res, next) {
-    res.status(200).type("json").end('{ "properties": { "provisioningState": "Succeeded"}, "id": "/lro/patch/202/retry/asyncAndLocationHeader", "name": "foo" }');
+    res
+      .status(200)
+      .type("json")
+      .end(
+        '{ "properties": { "provisioningState": "Succeeded"}, "id": "/lro/patch/202/retry/asyncAndLocationHeader", "name": "foo" }',
+      );
   });
 
   router.patch("/patch/202/retry/asyncAndLocationHeader", function (req, res, next) {
     var headers = {
-      "Azure-AsyncOperation": getRequestBaseUrl(req) + "/lro/patch/202/retry/asyncAndLocationHeader/operationResults/202",
-      "Location": getRequestBaseUrl(req) + "/lro/patch/202/retry/asyncAndLocationHeader/operationResults/202/finalResults/202"
+      "Azure-AsyncOperation":
+        getRequestBaseUrl(req) + "/lro/patch/202/retry/asyncAndLocationHeader/operationResults/202",
+      "Location":
+        getRequestBaseUrl(req) + "/lro/patch/202/retry/asyncAndLocationHeader/operationResults/202/finalResults/202",
     };
-    res.set(headers).status(202).type("json")
-      .end('{ "properties": { "provisioningState": "Succeeded"}, "id": "/lro/patch/202/retry/asyncAndLocationHeader", "name": "foo" }');
+    res
+      .set(headers)
+      .status(202)
+      .type("json")
+      .end(
+        '{ "properties": { "provisioningState": "Succeeded"}, "id": "/lro/patch/202/retry/asyncAndLocationHeader", "name": "foo" }',
+      );
   });
 
   router.get("/patch/202/retry/asyncAndLocationHeader/operationResults/202", function (req, res, next) {
     coverage["LROPatch202WithAsyncAndLocationHeader"]++;
     var status = "InProgress";
-    if(coverage["LROPatch202WithAsyncAndLocationHeader"] === 2) {
+    if (coverage["LROPatch202WithAsyncAndLocationHeader"] === 2) {
       status = "Succeeded";
     }
-    res.status(200).type("json").end('{ "status": "' + status + '" }');
+    res
+      .status(200)
+      .type("json")
+      .end('{ "status": "' + status + '" }');
   });
 
-  router.get("/patch/202/retry/asyncAndLocationHeader/operationResults/202/finalResults/202", function (req, res, next) {
-    res.status(200).type("json").end('{ "id": "/lro/patch/202/retry/asyncAndLocationHeader/operationResults/202/finalResults/202", "type": "AsyncAndLocationHeader/Operationresults/finalResults", "name": "202" }');
-  });
+  router.get(
+    "/patch/202/retry/asyncAndLocationHeader/operationResults/202/finalResults/202",
+    function (req, res, next) {
+      res
+        .status(200)
+        .type("json")
+        .end(
+          '{ "id": "/lro/patch/202/retry/asyncAndLocationHeader/operationResults/202/finalResults/202", "type": "AsyncAndLocationHeader/Operationresults/finalResults", "name": "202" }',
+        );
+    },
+  );
 
   coverage["LROPut202Retry200"] = 0;
   router.put("/put/202/retry/200", function (req, res, next) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/swagger/lro.json
+++ b/swagger/lro.json
@@ -85,9 +85,7 @@
     },
     "/lro/patch/201/retry/onlyAsyncHeader": {
       "patch": {
-        "tags": [
-          "LROs Operations"
-        ],
+        "tags": ["LROs Operations"],
         "description": "Long running patch request, service returns a 201 to the initial request with async header.",
         "operationId": "LROs_patch201RetryWithAsyncHeader",
         "x-ms-long-running-operation": true,
@@ -134,9 +132,7 @@
     },
     "/lro/patch/202/retry/asyncAndLocationHeader": {
       "patch": {
-        "tags": [
-          "LROs Operations"
-        ],
+        "tags": ["LROs Operations"],
         "description": "Long running patch request, service returns a 202 to the initial request with async and location header.",
         "operationId": "LROs_patch202RetryWithAsyncAndLocationHeader",
         "x-ms-long-running-operation": true,

--- a/swagger/lro.json
+++ b/swagger/lro.json
@@ -83,6 +83,105 @@
         }
       }
     },
+    "/lro/patch/201/retry/onlyAsyncHeader": {
+      "patch": {
+        "tags": [
+          "LROs Operations"
+        ],
+        "description": "Long running patch request, service returns a 201 to the initial request with async header.",
+        "operationId": "LROs_patch201RetryWithAsyncHeader",
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "parameters": [
+          {
+            "name": "product",
+            "description": "Product to patch",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product updated successfully.",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "201": {
+            "description": "Async operation to update products was created.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "description": "Location to poll for result status: will be set to /lro/patch/201/retry/onlyAsyncHeader/operationStatuses/201",
+                "type": "string"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/lro/patch/202/retry/asyncAndLocationHeader": {
+      "patch": {
+        "tags": [
+          "LROs Operations"
+        ],
+        "description": "Long running patch request, service returns a 202 to the initial request with async and location header.",
+        "operationId": "LROs_patch202RetryWithAsyncAndLocationHeader",
+        "x-ms-long-running-operation": true,
+        "parameters": [
+          {
+            "name": "product",
+            "description": "Product to patch",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product updated successfully.",
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "202": {
+            "description": "Async operation to update products was accpeted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "description": "Location to poll for result status: will be set to /lro/patch/202/retry/asyncAndLocationHeader/operationResults/202",
+                "type": "string"
+              },
+              "Location": {
+                "description": "Location to poll for final status: will be set to /lro/patch/202/retry/asyncAndLocationHeader/operationResults/202/finalResults/202",
+                "type": "string"
+              }
+            },
+            "schema": {
+              "$ref": "#/definitions/Product"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
     "/lro/put/201/succeeded": {
       "put": {
         "x-ms-long-running-operation": true,


### PR DESCRIPTION
Add two lro patch method tests to verify the Lro logic in .Net SDK. One will contain Azure-AsyncOperation header and another contains both Azure-AsyncOperation and Location Header.