### PR TITLE
Implement missing routes from DPG swaggers

### DIFF
--- a/src/test-routes/dpg/update.ts
+++ b/src/test-routes/dpg/update.ts
@@ -14,7 +14,7 @@ app.category("dpg", () => {
   app.head("/servicedriven/parameters", "DPGAddOptionalInput_NoParams", (req) => {
     return {
       status: 200,
-      headers: { "content-length": "0" },
+      headers: { "content-length": "123" },
     };
   });
 

--- a/src/test-routes/dpg/update.ts
+++ b/src/test-routes/dpg/update.ts
@@ -7,7 +7,9 @@ import { coverageService } from "../../services";
  */
 app.category("dpg", () => {
   /**
-   * Initially has no query parameters. After evolution, a new optional query parameter is added
+   * Initially has no query parameters. After evolution, a new optional query parameter is added.
+   * Note that when defining HEAD and GET methods for the same path, HEAD needs to be defined before
+   * GET. Otherwise Express would register the GET handler as the handler for both and the app.head would be ignored.
    */
   app.head("/servicedriven/parameters", "DPGAddOptionalInput_NoParams", (req) => {
     return {

--- a/src/test-routes/dpg/update.ts
+++ b/src/test-routes/dpg/update.ts
@@ -7,6 +7,16 @@ import { coverageService } from "../../services";
  */
 app.category("dpg", () => {
   /**
+   * Initially has no query parameters. After evolution, a new optional query parameter is added
+   */
+  app.head("/servicedriven/parameters", "DPGAddOptionalInput_NoParams", (req) => {
+    return {
+      status: 200,
+      headers: { "content-length": "0" },
+    };
+  });
+
+  /**
    * Initially only has one required Query Parameter. After evolution, a new optional query parameter is added.
    */
   app.get("/servicedriven/parameters", "DPGAddOptionalInput", (req) => {
@@ -21,16 +31,6 @@ app.category("dpg", () => {
         body: json({ message: `Expected required parameter "parameter"` }),
       };
     }
-  });
-
-  /**
-   * Initially has no query parameters. After evolution, a new optional query parameter is added
-   */
-  app.head("/servicedriven/parameters", "DPGAddOptionalInput_NoParams", (req) => {
-    return {
-      status: 200,
-      headers: { "content-length": "0" },
-    };
   });
 
   /**

--- a/src/test-routes/dpg/update.ts
+++ b/src/test-routes/dpg/update.ts
@@ -11,7 +11,6 @@ app.category("dpg", () => {
    */
   app.get("/servicedriven/parameters", "DPGAddOptionalInput", (req) => {
     if (req.query["parameter"]) {
-      coverageService.track("dpg", "DPGAddOptionalInput");
       return {
         status: 200,
         body: json({ message: `An object was successfully returned` }),
@@ -28,7 +27,6 @@ app.category("dpg", () => {
    * Initially has no query parameters. After evolution, a new optional query parameter is added
    */
   app.head("/servicedriven/parameters", "DPGAddOptionalInput_NoParams", (req) => {
-    coverageService.track("dpg", "DPGAddOptionalInput_NoParams");
     return {
       status: 200,
       headers: { "content-length": "0" },
@@ -40,7 +38,6 @@ app.category("dpg", () => {
    */
   app.put("/servicedriven/parameters", "DPGAddOptionalInput_RequiredOptionalParam", (req) => {
     if (req.query["requiredParam"]) {
-      coverageService.track("dpg", "DPGAddOptionalInput_RequiredOptionalParam");
       return {
         status: 200,
         body: json({ message: `An object was successfully returned` }),
@@ -57,7 +54,6 @@ app.category("dpg", () => {
    * Initially has one optional query parameter. After evolution, a new optional query parameter is added
    */
   app.get("/serviceDriven/moreParameters", "DPGAddOptionalInput_OptionalParam", (req) => {
-    coverageService.track("dpg", "DPGAddOptionalInput_OptionalParam");
     return {
       status: 200,
       body: json({ message: `An object was successfully returned` }),
@@ -88,7 +84,6 @@ app.category("dpg", () => {
    * Initially the path exists but there is no delete method. After evolution this is a new method in a known path
    */
   app.delete("/servicedriven/parameters", "DPGAddNewOperation", (req) => {
-    coverageService.track("dpg", "DPGAddNewOperation");
     return {
       status: 204,
     };
@@ -98,7 +93,6 @@ app.category("dpg", () => {
    * Initially neither path or method exist for this operation. After evolution, this is a new method in a new path
    */
   app.get("/servicedriven/newpath", "DPGAddNewPath", (req) => {
-    coverageService.track("dpg", "DPGAddNewPath");
     return {
       status: 200,
       body: json({ message: `An object was successfully returned` }),
@@ -109,7 +103,6 @@ app.category("dpg", () => {
    * An operation that is not part of the swagger definition but can be called
    */
   app.get("/servicedriven/glassbreaker", "DPGGlassBreaker", (req) => {
-    coverageService.track("dpg", "DPGGlassBreaker");
     return {
       status: 200,
       body: json({ message: `An object was successfully returned` }),

--- a/src/test-routes/dpg/update.ts
+++ b/src/test-routes/dpg/update.ts
@@ -1,17 +1,74 @@
 import { app, json, ValidationError } from "../../api";
 import { coverageService } from "../../services";
 
+/**
+ * Scenarios to test DPG and RLC Service driven evolution.
+ * These scenarios here are considered acceptable from an Azure breaking change policy
+ */
 app.category("dpg", () => {
+  /**
+   * Initially only has one required Query Parameter. After evolution, a new optional query parameter is added.
+   */
   app.get("/servicedriven/parameters", "DPGAddOptionalInput", (req) => {
+    if (req.query["parameter"]) {
+      coverageService.track("dpg", "DPGAddOptionalInput");
+      return {
+        status: 200,
+        body: json({ message: `An object was successfully returned` }),
+      };
+    } else {
+      return {
+        status: 400,
+        body: json({ message: `Expected required parameter "parameter"` }),
+      };
+    }
+  });
+
+  /**
+   * Initially has no query parameters. After evolution, a new optional query parameter is added
+   */
+  app.head("/servicedriven/parameters", "DPGAddOptionalInput_NoParams", (req) => {
+    coverageService.track("dpg", "DPGAddOptionalInput_NoParams");
+    return {
+      status: 200,
+      headers: { "content-length": "0" },
+    };
+  });
+
+  /**
+   * Initially has one required query parameter and one optional query parameter.  After evolution, a new optional query parameter is added
+   */
+  app.put("/servicedriven/parameters", "DPGAddOptionalInput_RequiredOptionalParam", (req) => {
+    if (req.query["requiredParam"]) {
+      coverageService.track("dpg", "DPGAddOptionalInput_RequiredOptionalParam");
+      return {
+        status: 200,
+        body: json({ message: `An object was successfully returned` }),
+      };
+    } else {
+      return {
+        status: 400,
+        body: json({ message: `Expected required parameter "requiredParam"` }),
+      };
+    }
+  });
+
+  /**
+   * Initially has one optional query parameter. After evolution, a new optional query parameter is added
+   */
+  app.get("/serviceDriven/moreParameters", "DPGAddOptionalInput_OptionalParam", (req) => {
+    coverageService.track("dpg", "DPGAddOptionalInput_OptionalParam");
     return {
       status: 200,
       body: json({ message: `An object was successfully returned` }),
     };
   });
 
+  /**
+   * A new body type is added (was JSON, and now JSON + JPEG).
+   */
   coverageService.register("dpg", "DPGNewBodyType.JSON");
   coverageService.register("dpg", "DPGNewBodyType.JPEG");
-
   app.post("/servicedriven/parameters", "DPGNewBodyType", (req) => {
     switch (req.headers["content-type"]) {
       case "image/jpeg":
@@ -27,13 +84,32 @@ app.category("dpg", () => {
     }
   });
 
+  /**
+   * Initially the path exists but there is no delete method. After evolution this is a new method in a known path
+   */
   app.delete("/servicedriven/parameters", "DPGAddNewOperation", (req) => {
+    coverageService.track("dpg", "DPGAddNewOperation");
     return {
       status: 204,
     };
   });
 
+  /**
+   * Initially neither path or method exist for this operation. After evolution, this is a new method in a new path
+   */
   app.get("/servicedriven/newpath", "DPGAddNewPath", (req) => {
+    coverageService.track("dpg", "DPGAddNewPath");
+    return {
+      status: 200,
+      body: json({ message: `An object was successfully returned` }),
+    };
+  });
+
+  /**
+   * An operation that is not part of the swagger definition but can be called
+   */
+  app.get("/servicedriven/glassbreaker", "DPGGlassBreaker", (req) => {
+    coverageService.track("dpg", "DPGGlassBreaker");
     return {
       status: 200,
       body: json({ message: `An object was successfully returned` }),

--- a/swagger/dpg_initial.json
+++ b/swagger/dpg_initial.json
@@ -6,15 +6,9 @@
     "description": "DPG Swagger, this is the initial swagger a service could do"
   },
   "host": "localhost:3000",
-  "schemes": [
-    "http"
-  ],
-  "produces": [
-    "application/json"
-  ],
-  "consumes": [
-    "application/json"
-  ],
+  "schemes": ["http"],
+  "produces": ["application/json"],
+  "consumes": ["application/json"],
   "paths": {
     "/serviceDriven/parameters": {
       "head": {
@@ -128,9 +122,7 @@
   "definitions": {
     "PostInput": {
       "type": "object",
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "properties": {
         "url": {
           "type": "string"

--- a/swagger/dpg_initial.json
+++ b/swagger/dpg_initial.json
@@ -6,14 +6,20 @@
     "description": "DPG Swagger, this is the initial swagger a service could do"
   },
   "host": "localhost:3000",
-  "schemes": ["http"],
-  "produces": ["application/json"],
-  "consumes": ["application/json"],
+  "schemes": [
+    "http"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
   "paths": {
     "/serviceDriven/parameters": {
       "head": {
         "operationId": "params_headNoParams",
-        "description": "Head request, no params",
+        "description": "Head request, no params.\n Initially has no query parameters. After evolution, a new optional query parameter is added",
         "parameters": [],
         "responses": {
           "200": {
@@ -26,7 +32,7 @@
       },
       "get": {
         "operationId": "params_getRequired",
-        "description": "Get true Boolean value on path",
+        "description": "Get true Boolean value on path.\n Initially only has one required Query Parameter. After evolution, a new optional query parameter is added",
         "parameters": [
           {
             "name": "parameter",
@@ -47,7 +53,7 @@
       },
       "put": {
         "operationId": "params_putRequiredOptional",
-        "description": "Put, has both required and optional params",
+        "description": "Initially has one required query parameter and one optional query parameter.  After evolution, a new optional query parameter is added",
         "parameters": [
           {
             "name": "requiredParam",
@@ -99,7 +105,7 @@
     "/serviceDriven/moreParameters": {
       "get": {
         "operationId": "params_getOptional",
-        "description": "Get true Boolean value on path",
+        "description": "Get true Boolean value on path.\n Initially has one optional query parameter. After evolution, a new optional query parameter is added",
         "parameters": [
           {
             "name": "optionalParam",
@@ -122,7 +128,9 @@
   "definitions": {
     "PostInput": {
       "type": "object",
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "properties": {
         "url": {
           "type": "string"

--- a/swagger/dpg_update1.json
+++ b/swagger/dpg_update1.json
@@ -6,12 +6,8 @@
     "description": "DPG Swagger, this is the initial swagger a service could do"
   },
   "host": "localhost:3000",
-  "schemes": [
-    "http"
-  ],
-  "produces": [
-    "application/json"
-  ],
+  "schemes": ["http"],
+  "produces": ["application/json"],
   "paths": {
     "/serviceDriven/parameters": {
       "head": {
@@ -97,10 +93,7 @@
       "post": {
         "operationId": "params_postParameters",
         "description": "POST a JSON or a JPEG",
-        "consumes": [
-          "application/json",
-          "image/jpeg"
-        ],
+        "consumes": ["application/json", "image/jpeg"],
         "parameters": [
           {
             "name": "parameter",
@@ -179,9 +172,7 @@
   "definitions": {
     "PostInput": {
       "type": "object",
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "properties": {
         "url": {
           "type": "string"

--- a/swagger/dpg_update1.json
+++ b/swagger/dpg_update1.json
@@ -6,13 +6,17 @@
     "description": "DPG Swagger, this is the initial swagger a service could do"
   },
   "host": "localhost:3000",
-  "schemes": ["http"],
-  "produces": ["application/json"],
+  "schemes": [
+    "http"
+  ],
+  "produces": [
+    "application/json"
+  ],
   "paths": {
     "/serviceDriven/parameters": {
       "head": {
         "operationId": "params_headNoParams",
-        "description": "Head request, no params",
+        "description": "Head request, no params. Initially has no query parameters. After evolution, a new optional query parameter is added",
         "parameters": [
           {
             "name": "new_parameter",
@@ -32,7 +36,7 @@
       },
       "get": {
         "operationId": "params_getRequired",
-        "description": "Get true Boolean value on path",
+        "description": "Get true Boolean value on path.\n Initially only has one required Query Parameter. After evolution, a new optional query parameter is added",
         "parameters": [
           {
             "name": "parameter",
@@ -59,7 +63,7 @@
       },
       "put": {
         "operationId": "params_putRequiredOptional",
-        "description": "Put, has both required and optional params",
+        "description": "Initially has one required query parameter and one optional query parameter.  After evolution, a new optional query parameter is added",
         "parameters": [
           {
             "name": "requiredParam",
@@ -93,7 +97,10 @@
       "post": {
         "operationId": "params_postParameters",
         "description": "POST a JSON or a JPEG",
-        "consumes": ["application/json", "image/jpeg"],
+        "consumes": [
+          "application/json",
+          "image/jpeg"
+        ],
         "parameters": [
           {
             "name": "parameter",
@@ -116,7 +123,7 @@
       },
       "delete": {
         "operationId": "params_deleteParameters",
-        "description": "Delete something",
+        "description": "Delete something.\n Initially the path exists but there is no delete method. After evolution this is a new method in a known path",
         "parameters": [],
         "responses": {
           "204": {
@@ -128,7 +135,7 @@
     "/serviceDriven/moreParameters": {
       "get": {
         "operationId": "params_getOptional",
-        "description": "Get true Boolean value on path",
+        "description": "Get true Boolean value on path.\n Initially has one optional query parameter. After evolution, a new optional query parameter is added",
         "parameters": [
           {
             "name": "optionalParam",
@@ -156,7 +163,7 @@
     "/serviceDriven/newPath": {
       "get": {
         "operationId": "params_getNewOperation",
-        "description": "I'm a new operation",
+        "description": "I'm a new operation.\n Initiallty neither path or method exist for this operation. After evolution, this is a new method in a new path",
         "parameters": [],
         "responses": {
           "200": {
@@ -172,7 +179,9 @@
   "definitions": {
     "PostInput": {
       "type": "object",
-      "required": ["url"],
+      "required": [
+        "url"
+      ],
       "properties": {
         "url": {
           "type": "string"


### PR DESCRIPTION
DPG Service Evolution swaggers contained a couple of routes that had no actual routes in the TestServer. This PR implements the missing routes.

- `app.head("/servicedriven/parameters", "DPGAddOptionalInput_NoParams")`
- ` app.put("/servicedriven/parameters", "DPGAddOptionalInput_RequiredOptionalParam")`
- `app.get("/serviceDriven/moreParameters", "DPGAddOptionalInput_OptionalParam")`
- `app.get("/servicedriven/glassbreaker", "DPGGlassBreaker")`