### PR TITLE
Save legacy route coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/src/services/coverage-service.ts
+++ b/src/services/coverage-service.ts
@@ -40,7 +40,7 @@ export class CoverageService {
 
   /**
    * For LEGACY test only.
-   * @depreacted
+   * @deprecated
    */
   public legacyTrack(category: string, name: string, value: number): void {
     let map = this.coverage[category];
@@ -53,6 +53,7 @@ export class CoverageService {
     }
 
     map[name] = value;
+    this.legacySaveCoverage(category);
   }
 
   public register(category: string, name: string): void {
@@ -83,6 +84,17 @@ export class CoverageService {
 
     try {
       await fs.promises.writeFile(path, JSON.stringify(categoryMap, null, 2));
+    } catch (e) {
+      logger.warn("Error while saving coverage", e);
+    }
+  }
+
+  private legacySaveCoverage(category: string) {
+    const categoryMap = this.coverage[category];
+    fs.mkdirSync(this.coverageDirectory, { recursive: true });
+    const path = join(this.coverageDirectory, `report-${category}.json`);
+    try {
+      fs.writeFileSync(path, JSON.stringify(categoryMap, null, 2));
     } catch (e) {
       logger.warn("Error while saving coverage", e);
     }


### PR DESCRIPTION
fix #345

While investigating autorest.go's disappointing testserver coverage, I observed that written coverage reports always record 0 hits for legacy routes. Turns out legacy hits are tracked but not written to disk. Here's a quick fix for that. I'm not familiar with the architecture here, so please let me know if you prefer a different fix.