### PR TITLE
add check about "api version" for "complex.js"

### DIFF
--- a/legacy/routes/complex.js
+++ b/legacy/routes/complex.js
@@ -10,6 +10,9 @@ var complex = function (coverage) {
    */
   router.put("/basic/:scenario", function (req, res, next) {
     if (req.params.scenario === "valid") {
+      if (req.query["api-version"] !== "2016-02-29") {
+        utils.send400(res, next, 'api version does not match 2016-02-29');
+      }
       if (_.isEqual(req.body, { id: 2, name: "abc", color: "Magenta" })) {
         coverage["putComplexBasicValid"]++;
         res.status(200).end();

--- a/legacy/routes/complex.js
+++ b/legacy/routes/complex.js
@@ -11,7 +11,7 @@ var complex = function (coverage) {
   router.put("/basic/:scenario", function (req, res, next) {
     if (req.params.scenario === "valid") {
       if (req.query["api-version"] !== "2016-02-29") {
-        utils.send400(res, next, 'api version does not match 2016-02-29');
+        utils.send400(res, next, "api version does not match 2016-02-29");
       }
       if (_.isEqual(req.body, { id: 2, name: "abc", color: "Magenta" })) {
         coverage["putComplexBasicValid"]++;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.3.25",
+  "version": "3.3.26",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {


### PR DESCRIPTION
https://github.com/Azure/autorest.python/issues/1267
The PR add check about "api version" which is ignored before. And it shall not break existing test for all languages.