### PR TITLE
add test for paging while overriding api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.3.29",
+  "version": "3.3.30",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/src/test-routes/paging.ts
+++ b/src/test-routes/paging.ts
@@ -27,4 +27,30 @@ app.category("azure", () => {
       };
     }
   });
+
+  app.get("/paging/apiVersion/:pagenumber", "PagingWithApiVersion", (req) => {
+    if (req.params.pagenumber === "1") {
+      return {
+        status: 200,
+        body: json({
+          values: [{ properties: { id: 1, name: "Product" } }],
+          nextLink: req.baseUrl + "/paging/apiVersion/2?Api-Version=notMe&%24skiptoken=bar",
+        }),
+      };
+    } else if (req.params.pagenumber === "2") {
+      req.expect.containsQueryParam("api-version", "1.0.0");
+      req.expect.containsQueryParam("$skiptoken", "bar");
+      return {
+        status: 200,
+        body: json({
+          values: [],
+        }),
+      };
+    } else {
+      return {
+        status: 400,
+        body: json("Wrong page number. Should only be 1 or 2"),
+      };
+    }
+  });
 });

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -604,6 +604,32 @@
           }
         }
       }
+    },
+    "/paging/apiVersion/1": {
+      "get": {
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink",
+          "itemName": "values"
+        },
+        "operationId": "Paging_pageWithApiVersion",
+        "description": "A paging operation with api version. When calling the next link, you want to reformat it and override the returned api version with your client's api version",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Initial response with ProvisioningState='Canceled'",
+            "schema": {
+              "$ref": "#/definitions/ProductResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
     }
   },
   "x-ms-paths": {
@@ -725,6 +751,15 @@
           }
         }
       }
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
     }
   },
   "definitions": {


### PR DESCRIPTION
If the client has an api version, we want to 1. append that api version to the next link if it doesn't exist OR 2. override the returned api version with that api version.

This test tests that we overide the returned api version in the next link, while preserving the other query parameter returned in the next link