### PR TITLE
Paging maxpagesize

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.3.30",
+  "version": "3.3.31",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {

--- a/src/test-routes/paging.ts
+++ b/src/test-routes/paging.ts
@@ -28,3 +28,20 @@ app.category("azure", () => {
     }
   });
 });
+
+app.category("optional", () => {
+  app.get("/paging/maxPageSize", "PagingDontSendMaxPageSize", (req) => {
+    if (req.query["$maxpagesize"] !== undefined) {
+      return {
+        status: 400,
+        body: json("Should not send maxpagesize."),
+      };
+    }
+    return {
+      status: 200,
+      body: json({
+        values: [],
+      }),
+    };
+  });
+});

--- a/swagger/paging.json
+++ b/swagger/paging.json
@@ -216,6 +216,41 @@
         }
       }
     },
+    "/paging/maxPageSize": {
+      "get": {
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink",
+          "itemName": "values"
+        },
+        "operationId": "Paging_pageWithMaxPageSize",
+        "description": "Paging with max page size. We don't want to ",
+        "parameters": [
+          {
+            "name": "$maxpagesize",
+            "in": "query",
+            "description": "Max page size query param. Don't send",
+            "required": false,
+            "type": "string",
+            "enum": ["5"],
+            "x-ms-enum": {
+              "name": "MaxPageSizeType",
+              "modelAsString": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Initial response with ProvisioningState='Canceled'",
+            "schema": {
+              "$ref": "#/definitions/ProductResult"
+            }
+          },
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
     "/paging/multiple/nextOperationWithQueryParams": {
       "get": {
         "x-ms-pageable": {


### PR DESCRIPTION
python doesn't want to expose maxpagesize. Adding a test where we don't generate with it, and adding an optional testserver test to make sure it's not sent