### PR TITLE
Accept api-version parameter in path - paging/multiple/nextOperationWithQueryParams

### DIFF
--- a/legacy/routes/paging.js
+++ b/legacy/routes/paging.js
@@ -89,7 +89,11 @@ var paging = function (coverage) {
   });
 
   router.get("/multiple/nextOperationWithQueryParams", function (req, res, next) {
-    if (Object.keys(req.query).length <= 1 && req.query["queryConstant"] === "true") {
+    if (
+      ((Object.keys(req.query).length <= 2 && req.query["api-version"] == "1.0.0") ||
+        Object.keys(req.query).length <= 1) &&
+      req.query["queryConstant"] === "true"
+    ) {
       coverage["PagingMultipleWithQueryParameters"]++;
       res.status(200).json({ values: [{ properties: { id: 2, name: "Product" } }] });
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.3.31",
+  "version": "3.3.32",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {


### PR DESCRIPTION
# Issue:
The path - ` paging/multiple/nextOperationWithQueryParams` with api-version will return 400
Request: http://localhost:3000/paging/multiple/nextOperationWithQueryParams?queryConstant=true&api-version=1.0.0
Response: error: Error The query parameters to nextOperationWithQueryParams were not passed correctly {"status":400}
info: GET /paging/multiple/nextOperationWithQueryParams?queryConstant=true&api-version=1.0.0 400 1.006 ms – 105

# After fix:
Below two paths are accepted after fixing it:
•	Without api-version:
Request: http://localhost:3000/paging/multiple/nextOperationWithQueryParams?queryConstant=true
Response: info: info: GET /paging/multiple/nextOperationWithQueryParams?queryConstant=true 200 13.812 ms - 53
•	With api-version:
Request: http://localhost:3000/paging/multiple/nextOperationWithQueryParams?queryConstant=true&api-version=1.0.0
Response: info: GET /paging/multiple/nextOperationWithQueryParams?queryConstant=true&api-version=1.0.0 304 1.841 ms - -

