### PR TITLE
Remove tests that require User-Agent and x-ms-client-request-id override

### DIFF
--- a/legacy/routes/header.js
+++ b/legacy/routes/header.js
@@ -8,18 +8,7 @@ var header = function (coverage, optionalCoverage) {
   optionalCoverage["HeaderParameterProtectedKey"] = 1; // NOT A THING
   optionalCoverage["CustomHeaderInRequest"] = 0;
   router.post("/param/:scenario", function (req, res, next) {
-    if (req.params.scenario === "existingkey") {
-      if (req.get("User-Agent") === "overwrite") {
-        coverage["HeaderParameterExistingKey"]++;
-        res.status(200).end();
-      } else {
-        utils.send400(
-          res,
-          next,
-          'Did not like scenario "' + req.params.scenario + '" with value ' + req.get("User-Agent"),
-        );
-      }
-    } else if (req.params.scenario === "protectedkey") {
+    if (req.params.scenario === "protectedkey") {
       //We are making this change in the test server because for data plane we have to support scenarios where the user can override
       //the protected header like Content-Type by providing one.
       if (req.get("Content-Type") === "text/html") {
@@ -34,15 +23,6 @@ var header = function (coverage, optionalCoverage) {
       }
     } else {
       utils.send400(res, next, 'Did not like scenario "' + req.params.scenario);
-    }
-  });
-
-  router.post("/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0", function (req, res, next) {
-    if (req.get("x-ms-client-request-id").toLowerCase() === "9C4D50EE-2D56-4CD3-8152-34347DC9F2B0".toLowerCase()) {
-      optionalCoverage["CustomHeaderInRequest"]++;
-      res.status(200).end();
-    } else {
-      utils.send400(res, next, 'Did not like client request id "' + req.get("x-ms-client-request-id"));
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "format": "npm run -s prettier -- --write",
     "check-format": "npm run -s prettier -- --check",
     "prettier": "prettier --config ./.prettierrc.yml **/*.{ts,js,cjs,mjs,json,yml,yaml,md}",
-    "validate-spec-coverage": "node ./dist/cli/cli.js validate-spec-coverage --maxErrorCount=77"
+    "validate-spec-coverage": "node ./dist/cli/cli.js validate-spec-coverage --maxErrorCount=76"
   },
   "engines": {
     "node": ">=10"

--- a/swagger/examples/header_paramExistingKey.json
+++ b/swagger/examples/header_paramExistingKey.json
@@ -1,8 +1,0 @@
-{
-  "parameters": {
-    "User-Agent": "overwrite"
-  },
-  "responses": {
-    "200": {}
-  }
-}

--- a/swagger/header.json
+++ b/swagger/header.json
@@ -10,38 +10,6 @@
   "produces": ["application/json"],
   "consumes": ["application/json"],
   "paths": {
-    "/header/param/existingkey": {
-      "post": {
-        "operationId": "header_paramExistingKey",
-        "description": "Send a post request with header value \"User-Agent\": \"overwrite\"",
-        "x-ms-examples": {
-          "header_paramExistingKey": {
-            "$ref": "./examples/header_paramExistingKey.json"
-          }
-        },
-        "tags": ["Header Operations"],
-        "parameters": [
-          {
-            "description": "Send a post request with header value \"User-Agent\": \"overwrite\"",
-            "name": "User-Agent",
-            "in": "header",
-            "type": "string",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Empty Response"
-          },
-          "default": {
-            "description": "Unexpected error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
     "/header/response/existingkey": {
       "post": {
         "operationId": "header_responseExistingKey",


### PR DESCRIPTION
Please help me to find out the truth: either all SDK should implement conformance to these 2 scenarios, or it should not be allowed - so then the scenarios should be removed, and these SDKs who have logic to make it work probably need to undo the code that they have to enable it.

* Java, .NET, and Python do allow to override `User-Agent`, C++ and Go do not;
* .NET, Python, and Go do allow to override `x-ms-client-request-id`, C++ does not.

I am having several conversations with people saying that `User-Agent` and `x-ms-client-request-id` overriding should not be allowed:

* https://github.com/Azure/azure-sdk-for-go/issues/19890
* https://github.com/Azure/azure-sdk-for-cpp/pull/4303#discussion_r1091537785
