### PR TITLE
build: bump version to 3.3.50

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.3.49",
+  "version": "3.3.50",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {


### PR DESCRIPTION
Bump a new version to deliver the security fixed to downstream packages.

For example, `autorest.csharp` imports `autorest.testserver`: https://github.com/Azure/autorest.csharp/blob/68e44c384b4809bb4c1e989571ba19f081c3ff48/package.json#L19