### PR TITLE
Bump express package from 4.17.2 to 4.21.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   },
   "dependencies": {
     "@azure/storage-blob": "^12.11.0",
+    "@microsoft.azure/autorest.testserver": "file:",
     "body-parser": "^1.19.1",
     "busboy": "^1.6.0",
     "commonmark": "^0.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.testserver",
-  "version": "3.3.50",
+  "version": "3.3.51",
   "description": "Autorest test server.",
   "main": "dist/cli/cli.js",
   "bin": {
@@ -74,7 +74,7 @@
     "busboy": "^1.6.0",
     "commonmark": "^0.30.0",
     "deep-equal": "^2.0.5",
-    "express": "^4.17.2",
+    "express": "^4.21.2",
     "express-promise-router": "^4.1.1",
     "glob": "^8.0.3",
     "js-yaml": "~4.1.0",


### PR DESCRIPTION
Fixes #427
The express package need to be bumped to address a security vulnerability in ``path-to-regexp`` package. Please refer to the PR over here https://github.com/expressjs/express/pull/6209 